### PR TITLE
Implement fstab Generation

### DIFF
--- a/src/c.rs
+++ b/src/c.rs
@@ -1,6 +1,10 @@
 extern crate libc;
 
 use self::libc::{size_t, uint16_t, uint64_t, uint8_t};
+use super::{
+    log, Bootloader, Config, Disk, Disks, Error, FileSystemType, Installer, PartitionBuilder,
+    PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector, Status, Step,
+};
 use std::ffi::{CStr, CString, OsStr};
 use std::io;
 use std::mem;
@@ -8,9 +12,6 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::ptr;
 use std::slice;
-use super::{log, Bootloader, Config, Disk, Disks, Error, FileSystemType, Installer,
-            PartitionBuilder, PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector,
-            Status, Step};
 
 /// Log level
 #[repr(C)]
@@ -72,8 +73,8 @@ impl From<Step> for DISTINST_STEP {
 #[derive(Debug)]
 pub struct DistinstConfig {
     squashfs: *const libc::c_char,
-    lang: *const libc::c_char,
-    remove: *const libc::c_char,
+    lang:     *const libc::c_char,
+    remove:   *const libc::c_char,
 }
 
 impl DistinstConfig {
@@ -122,8 +123,8 @@ impl DistinstConfig {
 
         Ok(Config {
             squashfs: squashfs.to_string(),
-            lang: lang.to_string(),
-            remove: remove.to_string(),
+            lang:     lang.to_string(),
+            remove:   remove.to_string(),
         })
     }
 }
@@ -133,7 +134,7 @@ impl DistinstConfig {
 #[derive(Copy, Clone, Debug)]
 pub struct DistinstError {
     step: DISTINST_STEP,
-    err: libc::c_int,
+    err:  libc::c_int,
 }
 
 /// Installer error callback
@@ -144,7 +145,7 @@ pub type DistinstErrorCallback =
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct DistinstStatus {
-    step: DISTINST_STEP,
+    step:    DISTINST_STEP,
     percent: libc::c_int,
 }
 
@@ -200,7 +201,7 @@ pub unsafe extern "C" fn distinst_installer_emit_error(
 ) {
     (*(installer as *mut Installer)).emit_error(&Error {
         step: (*error).step.into(),
-        err: io::Error::from_raw_os_error((*error).err),
+        err:  io::Error::from_raw_os_error((*error).err),
     });
 }
 
@@ -215,7 +216,7 @@ pub unsafe extern "C" fn distinst_installer_on_error(
         callback(
             &DistinstError {
                 step: error.step.into(),
-                err: error.err.raw_os_error().unwrap_or(libc::EIO),
+                err:  error.err.raw_os_error().unwrap_or(libc::EIO),
             } as *const DistinstError,
             user_data,
         )
@@ -229,7 +230,7 @@ pub unsafe extern "C" fn distinst_installer_emit_status(
     status: *const DistinstStatus,
 ) {
     (*(installer as *mut Installer)).emit_status(&Status {
-        step: (*status).step.into(),
+        step:    (*status).step.into(),
         percent: (*status).percent,
     });
 }
@@ -244,7 +245,7 @@ pub unsafe extern "C" fn distinst_installer_on_status(
     (*(installer as *mut Installer)).on_status(move |status| {
         callback(
             &DistinstStatus {
-                step: status.step.into(),
+                step:    status.step.into(),
                 percent: status.percent,
             } as *const DistinstStatus,
             user_data,
@@ -282,7 +283,7 @@ pub unsafe extern "C" fn distinst_installer_install(
             let errno = err.raw_os_error().unwrap_or(libc::EIO);
             (*(installer as *mut Installer)).emit_error(&Error {
                 step: Step::Init,
-                err: err,
+                err:  err,
             });
             errno
         }
@@ -498,8 +499,8 @@ pub unsafe extern "C" fn strfilesys(fs: DISTINST_FILE_SYSTEM_TYPE) -> *const lib
 
 #[repr(C)]
 pub struct DistinstDisks {
-    disks: *mut DistinstDisk,
-    length: size_t,
+    disks:    *mut DistinstDisk,
+    length:   size_t,
     capacity: size_t,
 }
 
@@ -524,8 +525,8 @@ pub unsafe extern "C" fn distinst_disks_new() -> *mut DistinstDisks {
 
             pdisks.shrink_to_fit();
             let new_disks = DistinstDisks {
-                disks: pdisks.as_mut_ptr(),
-                length: pdisks.len(),
+                disks:    pdisks.as_mut_ptr(),
+                length:   pdisks.len(),
                 capacity: pdisks.len(),
             };
 
@@ -591,29 +592,29 @@ pub unsafe extern "C" fn distinst_disks_destroy(disks: *mut DistinstDisks) {
 
 #[repr(C)]
 pub struct DistinstDisk {
-    model_name: *mut libc::c_char,
-    serial: *mut libc::c_char,
+    model_name:  *mut libc::c_char,
+    serial:      *mut libc::c_char,
     device_path: *mut libc::c_char,
     device_type: *mut libc::c_char,
-    sectors: uint64_t,
+    sectors:     uint64_t,
     sector_size: uint64_t,
-    partitions: DistinstPartitions,
-    table_type: DISTINST_PARTITION_TABLE,
-    read_only: uint8_t,
+    partitions:  DistinstPartitions,
+    table_type:  DISTINST_PARTITION_TABLE,
+    read_only:   uint8_t,
 }
 
 impl Clone for DistinstDisk {
     fn clone(&self) -> DistinstDisk {
         DistinstDisk {
-            model_name: clone_cstr(self.model_name),
-            serial: clone_cstr(self.serial),
+            model_name:  clone_cstr(self.model_name),
+            serial:      clone_cstr(self.serial),
             device_path: clone_cstr(self.device_path),
             device_type: clone_cstr(self.device_type),
-            sectors: self.sectors,
+            sectors:     self.sectors,
             sector_size: self.sector_size,
-            partitions: self.partitions.clone(),
-            table_type: self.table_type,
-            read_only: self.read_only,
+            partitions:  self.partitions.clone(),
+            table_type:  self.table_type,
+            read_only:   self.read_only,
         }
     }
 }
@@ -639,7 +640,7 @@ impl From<Disk> for DistinstDisk {
             .collect();
         parts.shrink_to_fit();
         let partitions = DistinstPartitions {
-            parts: parts.as_mut_ptr(),
+            parts:  parts.as_mut_ptr(),
             length: parts.len(),
         };
 
@@ -667,19 +668,19 @@ impl From<DistinstDisk> for Disk {
         let (parts, plen) = (disk.partitions.parts, disk.partitions.length);
 
         Disk {
-            model_name: from_ptr_to_string(disk.model_name),
-            serial: from_ptr_to_string(disk.serial),
+            model_name:  from_ptr_to_string(disk.model_name),
+            serial:      from_ptr_to_string(disk.serial),
             device_path: from_ptr_to_path(disk.device_path),
-            size: disk.sectors as u64,
+            size:        disk.sectors as u64,
             sector_size: disk.sector_size as u64,
             device_type: from_ptr_to_string(disk.device_type),
-            table_type: match disk.table_type {
+            table_type:  match disk.table_type {
                 DISTINST_PARTITION_TABLE::GPT => Some(PartitionTable::Gpt),
                 DISTINST_PARTITION_TABLE::MSDOS => Some(PartitionTable::Msdos),
                 DISTINST_PARTITION_TABLE::NONE => None,
             },
-            read_only: disk.read_only != 0,
-            partitions: unsafe { Vec::from_raw_parts(parts, plen, plen) }
+            read_only:   disk.read_only != 0,
+            partitions:  unsafe { Vec::from_raw_parts(parts, plen, plen) }
                 .into_iter()
                 .map(PartitionInfo::from)
                 .collect::<Vec<_>>(),
@@ -690,7 +691,7 @@ impl From<DistinstDisk> for Disk {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct DistinstSector {
-    flag: DISTINST_SECTOR_KIND,
+    flag:  DISTINST_SECTOR_KIND,
     value: uint64_t,
 }
 
@@ -719,7 +720,7 @@ impl From<DistinstSector> for Sector {
 #[no_mangle]
 pub unsafe extern "C" fn distinst_sector_start() -> DistinstSector {
     DistinstSector {
-        flag: DISTINST_SECTOR_KIND::START,
+        flag:  DISTINST_SECTOR_KIND::START,
         value: 0,
     }
 }
@@ -727,7 +728,7 @@ pub unsafe extern "C" fn distinst_sector_start() -> DistinstSector {
 #[no_mangle]
 pub unsafe extern "C" fn distinst_sector_end() -> DistinstSector {
     DistinstSector {
-        flag: DISTINST_SECTOR_KIND::END,
+        flag:  DISTINST_SECTOR_KIND::END,
         value: 0,
     }
 }
@@ -743,7 +744,7 @@ pub unsafe extern "C" fn distinst_sector_megabyte(value: uint64_t) -> DistinstSe
 #[no_mangle]
 pub unsafe extern "C" fn distinst_sector_percent(value: uint16_t) -> DistinstSector {
     DistinstSector {
-        flag: DISTINST_SECTOR_KIND::PERCENT,
+        flag:  DISTINST_SECTOR_KIND::PERCENT,
         value: value as uint64_t,
     }
 }
@@ -931,12 +932,12 @@ pub unsafe extern "C" fn distinst_disk_commit(disk: *mut *mut DistinstDisk) -> l
 #[repr(C)]
 pub struct DistinstPartitionBuilder {
     start_sector: uint64_t,
-    end_sector: uint64_t,
-    filesystem: DISTINST_FILE_SYSTEM_TYPE,
-    part_type: DISTINST_PARTITION_TYPE,
-    name: *mut libc::c_char,
-    target: *mut libc::c_char,
-    flags: DistinstPartitionFlags,
+    end_sector:   uint64_t,
+    filesystem:   DISTINST_FILE_SYSTEM_TYPE,
+    part_type:    DISTINST_PARTITION_TYPE,
+    name:         *mut libc::c_char,
+    target:       *mut libc::c_char,
+    flags:        DistinstPartitionFlags,
 }
 
 impl Drop for DistinstPartitionBuilder {
@@ -953,13 +954,13 @@ impl From<DistinstPartitionBuilder> for PartitionBuilder {
 
         PartitionBuilder {
             start_sector: distinst.start_sector as u64,
-            end_sector: distinst.end_sector as u64,
-            filesystem: Option::<FileSystemType>::from(distinst.filesystem).unwrap(),
-            part_type: match distinst.part_type {
+            end_sector:   distinst.end_sector as u64,
+            filesystem:   Option::<FileSystemType>::from(distinst.filesystem).unwrap(),
+            part_type:    match distinst.part_type {
                 DISTINST_PARTITION_TYPE::LOGICAL => PartitionType::Logical,
                 DISTINST_PARTITION_TYPE::PRIMARY => PartitionType::Primary,
             },
-            name: if distinst.name.is_null() {
+            name:         if distinst.name.is_null() {
                 None
             } else {
                 match String::from_utf8(unsafe { CString::from_raw(distinst.name).into_bytes() }) {
@@ -970,7 +971,7 @@ impl From<DistinstPartitionBuilder> for PartitionBuilder {
                     }
                 }
             },
-            flags: unsafe {
+            flags:        unsafe {
                 Vec::from_raw_parts(
                     distinst.flags.flags,
                     distinst.flags.length,
@@ -979,7 +980,7 @@ impl From<DistinstPartitionBuilder> for PartitionBuilder {
                     .map(PartitionFlag::from)
                     .collect()
             },
-            mount: if distinst.target.is_null() {
+            mount:        if distinst.target.is_null() {
                 None
             } else {
                 Some(from_ptr_to_path(distinst.target))
@@ -1070,41 +1071,41 @@ pub unsafe extern "C" fn distinst_partition_builder_add_flag(
 
 #[repr(C)]
 pub struct DistinstPartition {
-    is_source: uint8_t,
-    remove: uint8_t,
-    format: uint8_t,
-    active: uint8_t,
-    busy: uint8_t,
-    part_type: DISTINST_PARTITION_TYPE,
-    filesystem: DISTINST_FILE_SYSTEM_TYPE,
-    number: libc::int32_t,
+    is_source:    uint8_t,
+    remove:       uint8_t,
+    format:       uint8_t,
+    active:       uint8_t,
+    busy:         uint8_t,
+    part_type:    DISTINST_PARTITION_TYPE,
+    filesystem:   DISTINST_FILE_SYSTEM_TYPE,
+    number:       libc::int32_t,
     start_sector: uint64_t,
-    end_sector: uint64_t,
-    flags: DistinstPartitionFlags,
-    name: *mut libc::c_char,
-    device_path: *mut libc::c_char,
-    mount_point: *mut libc::c_char,
-    target: *mut libc::c_char,
+    end_sector:   uint64_t,
+    flags:        DistinstPartitionFlags,
+    name:         *mut libc::c_char,
+    device_path:  *mut libc::c_char,
+    mount_point:  *mut libc::c_char,
+    target:       *mut libc::c_char,
 }
 
 impl Clone for DistinstPartition {
     fn clone(&self) -> DistinstPartition {
         DistinstPartition {
-            is_source: self.is_source,
-            remove: self.remove,
-            format: self.format,
-            active: self.active,
-            busy: self.busy,
-            part_type: self.part_type,
-            filesystem: self.filesystem,
-            number: self.number,
+            is_source:    self.is_source,
+            remove:       self.remove,
+            format:       self.format,
+            active:       self.active,
+            busy:         self.busy,
+            part_type:    self.part_type,
+            filesystem:   self.filesystem,
+            number:       self.number,
             start_sector: self.start_sector,
-            end_sector: self.end_sector,
-            flags: self.flags.clone(),
-            name: clone_cstr(self.name),
-            device_path: clone_cstr(self.device_path),
-            mount_point: clone_cstr(self.mount_point),
-            target: clone_cstr(self.target),
+            end_sector:   self.end_sector,
+            flags:        self.flags.clone(),
+            name:         clone_cstr(self.name),
+            device_path:  clone_cstr(self.device_path),
+            mount_point:  clone_cstr(self.mount_point),
+            target:       clone_cstr(self.target),
         }
     }
 }
@@ -1118,8 +1119,8 @@ impl From<PartitionInfo> for DistinstPartition {
         pflags.shrink_to_fit();
 
         let flags = DistinstPartitionFlags {
-            flags: pflags.as_mut_ptr(),
-            length: pflags.len(),
+            flags:    pflags.as_mut_ptr(),
+            length:   pflags.len(),
             capacity: pflags.capacity(),
         };
 
@@ -1154,37 +1155,37 @@ impl From<DistinstPartition> for PartitionInfo {
     fn from(part: DistinstPartition) -> PartitionInfo {
         let (flags, flen) = (part.flags.flags, part.flags.length);
         PartitionInfo {
-            is_source: part.is_source != 0,
-            remove: part.remove != 0,
-            format: part.format != 0,
-            active: part.active != 0,
-            busy: part.busy != 0,
-            number: part.number as i32,
+            is_source:    part.is_source != 0,
+            remove:       part.remove != 0,
+            format:       part.format != 0,
+            active:       part.active != 0,
+            busy:         part.busy != 0,
+            number:       part.number as i32,
             start_sector: part.start_sector as u64,
-            end_sector: part.end_sector as u64,
-            part_type: match part.part_type {
+            end_sector:   part.end_sector as u64,
+            part_type:    match part.part_type {
                 DISTINST_PARTITION_TYPE::LOGICAL => PartitionType::Logical,
                 DISTINST_PARTITION_TYPE::PRIMARY => PartitionType::Primary,
             },
-            filesystem: Option::<FileSystemType>::from(part.filesystem),
-            flags: unsafe {
+            filesystem:   Option::<FileSystemType>::from(part.filesystem),
+            flags:        unsafe {
                 Vec::from_raw_parts(flags, flen, flen)
                     .into_iter()
                     .map(PartitionFlag::from)
                     .collect()
             },
-            name: if part.name.is_null() {
+            name:         if part.name.is_null() {
                 None
             } else {
                 Some(from_ptr_to_string(part.name))
             },
-            device_path: from_ptr_to_path(part.device_path),
-            mount_point: if part.mount_point.is_null() {
+            device_path:  from_ptr_to_path(part.device_path),
+            mount_point:  if part.mount_point.is_null() {
                 None
             } else {
                 Some(from_ptr_to_path(part.mount_point))
             },
-            target: if part.target.is_null() {
+            target:       if part.target.is_null() {
                 None
             } else {
                 Some(from_ptr_to_path(part.target))
@@ -1195,21 +1196,21 @@ impl From<DistinstPartition> for PartitionInfo {
 
 #[repr(C)]
 pub struct DistinstPartitionFlags {
-    flags: *mut DISTINST_PARTITION_FLAG,
-    length: size_t,
+    flags:    *mut DISTINST_PARTITION_FLAG,
+    length:   size_t,
     capacity: size_t,
 }
 
 impl Clone for DistinstPartitionFlags {
     fn clone(&self) -> Self {
         DistinstPartitionFlags {
-            flags: unsafe {
+            flags:    unsafe {
                 let mut vec = slice::from_raw_parts(self.flags, self.length).to_owned();
                 let ptr = vec.as_mut_ptr();
                 mem::forget(vec);
                 ptr
             },
-            length: self.length,
+            length:   self.length,
             capacity: self.capacity,
         }
     }
@@ -1223,14 +1224,14 @@ impl Drop for DistinstPartitionFlags {
 
 #[repr(C)]
 pub struct DistinstPartitions {
-    parts: *mut DistinstPartition,
+    parts:  *mut DistinstPartition,
     length: size_t,
 }
 
 impl Clone for DistinstPartitions {
     fn clone(&self) -> Self {
         DistinstPartitions {
-            parts: unsafe {
+            parts:  unsafe {
                 let mut vec = slice::from_raw_parts(self.parts, self.length).to_owned();
                 let ptr = vec.as_mut_ptr();
                 mem::forget(vec);

--- a/src/c.rs
+++ b/src/c.rs
@@ -1,6 +1,6 @@
 extern crate libc;
 
-use self::libc::{size_t, uint64_t, uint8_t, uint16_t};
+use self::libc::{size_t, uint16_t, uint64_t, uint8_t};
 use std::ffi::{CStr, CString, OsStr};
 use std::io;
 use std::mem;

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -6,12 +6,12 @@ use std::process::{Command, ExitStatus};
 use mount::{Mount, MountOption};
 
 pub struct Chroot {
-    path: PathBuf,
-    dev_mount: Mount,
-    pts_mount: Mount,
+    path:       PathBuf,
+    dev_mount:  Mount,
+    pts_mount:  Mount,
     proc_mount: Mount,
-    run_mount: Mount,
-    sys_mount: Mount,
+    run_mount:  Mount,
+    sys_mount:  Mount,
 }
 
 impl Chroot {
@@ -27,12 +27,12 @@ impl Chroot {
         let run_mount = Mount::new("/run", path.join("run"), &[MountOption::Bind])?;
         let sys_mount = Mount::new("/sys", path.join("sys"), &[MountOption::Bind])?;
         Ok(Chroot {
-            path: path,
-            dev_mount: dev_mount,
-            pts_mount: pts_mount,
+            path:       path,
+            dev_mount:  dev_mount,
+            pts_mount:  pts_mount,
             proc_mount: proc_mount,
-            run_mount: run_mount,
-            sys_mount: sys_mount,
+            run_mount:  run_mount,
+            sys_mount:  sys_mount,
         })
     }
 

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -18,7 +18,11 @@ impl Chroot {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Chroot> {
         let path = path.as_ref().canonicalize()?;
         let dev_mount = Mount::new("/dev", path.join("dev"), &[MountOption::Bind])?;
-        let pts_mount = Mount::new("/dev/pts", path.join("dev").join("pts"), &[MountOption::Bind])?;
+        let pts_mount = Mount::new(
+            "/dev/pts",
+            path.join("dev").join("pts"),
+            &[MountOption::Bind],
+        )?;
         let proc_mount = Mount::new("/proc", path.join("proc"), &[MountOption::Bind])?;
         let run_mount = Mount::new("/run", path.join("run"), &[MountOption::Bind])?;
         let sys_mount = Mount::new("/sys", path.join("sys"), &[MountOption::Bind])?;
@@ -32,7 +36,11 @@ impl Chroot {
         })
     }
 
-    pub fn command<S: AsRef<OsStr>, T: AsRef<OsStr>, I: IntoIterator<Item=T>>(&mut self, cmd: S, args: I) -> Result<ExitStatus> {
+    pub fn command<S: AsRef<OsStr>, T: AsRef<OsStr>, I: IntoIterator<Item = T>>(
+        &mut self,
+        cmd: S,
+        args: I,
+    ) -> Result<ExitStatus> {
         let mut command = Command::new("chroot");
         command.arg(&self.path);
         command.arg(cmd.as_ref());

--- a/src/configure.sh
+++ b/src/configure.sh
@@ -27,10 +27,6 @@ dbus-uuidgen > /var/lib/dbus/machine-id
 # Correctly specify resolv.conf
 ln -sf ../run/resolvconf/resolv.conf /etc/resolv.conf
 
-# Create fstab
-echo "# /etc/fstab: static file system information." | tee /etc/fstab
-echo "# <file system> <mount point> <type> <options> <dump> <pass>" | tee -a /etc/fstab
-
 ROOTDEV="$(df --output=source / | sed 1d)"
 ROOTUUID="$(blkid -o value -s UUID "${ROOTDEV}")"
 echo "# / was on ${ROOTDEV} during installation" | tee -a /etc/fstab

--- a/src/configure.sh
+++ b/src/configure.sh
@@ -27,22 +27,6 @@ dbus-uuidgen > /var/lib/dbus/machine-id
 # Correctly specify resolv.conf
 ln -sf ../run/resolvconf/resolv.conf /etc/resolv.conf
 
-ROOTDEV="$(df --output=source / | sed 1d)"
-ROOTUUID="$(blkid -o value -s UUID "${ROOTDEV}")"
-echo "# / was on ${ROOTDEV} during installation" | tee -a /etc/fstab
-echo "UUID=${ROOTUUID} / ext4 errors=remount-ro 0 1" | tee -a /etc/fstab
-
-if [ -d /boot/efi/ ]
-then
-    EFIDEV="$(df --output=source /boot/efi/ | sed 1d)"
-    if [ "${EFIDEV}" != "${ROOTDEV}" ]
-    then
-        EFIUUID="$(blkid -o value -s UUID "${EFIDEV}")"
-        echo "# /boot/efi was on ${EFIDEV} during installation" | tee -a /etc/fstab
-        echo "UUID=${EFIUUID} /boot/efi vfat umask=0077 0 1" | tee -a /etc/fstab
-    fi
-fi
-
 # Update locales
 locale-gen --purge "${LANG}"
 update-locale --reset "LANG=${LANG}"

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -3,17 +3,17 @@ mod operations;
 mod partitions;
 mod serial;
 
-use libparted::{Device, DeviceType, Disk as PedDisk, DiskType as PedDiskType};
 use self::mounts::Mounts;
-use self::serial::get_serial_no;
 use self::operations::*;
 pub use self::partitions::{FileSystemType, PartitionBuilder, PartitionInfo, PartitionType};
+use self::serial::get_serial_no;
+use libparted::{Device, DeviceType, Disk as PedDisk, DiskType as PedDiskType};
+pub use libparted::PartitionFlag;
 use std::ffi::OsString;
 use std::io;
 use std::iter::FromIterator;
-use std::str;
 use std::path::{Path, PathBuf};
-pub use libparted::PartitionFlag;
+use std::str;
 
 /// Defines a variety of errors that may arise from configuring and committing changes to disks.
 #[derive(Debug, Fail)]
@@ -68,7 +68,7 @@ pub enum DiskError {
     #[fail(display = "unable to remove partition {}: {}", partition, why)]
     PartitionRemove {
         partition: i32,
-        why: io::Error,
+        why:       io::Error,
     },
     #[fail(display = "unable to resize partition")] PartitionResize,
     #[fail(display = "partition table not found on disk")] PartitionTableNotFound,
@@ -453,7 +453,8 @@ impl Disk {
         Ok(())
     }
 
-    /// Designates that the specified partition ID should be formatted with the given file system.
+    /// Designates that the specified partition ID should be formatted with the given file
+    /// system.
     pub fn format_partition(
         &mut self,
         partition: i32,
@@ -568,15 +569,15 @@ impl Disk {
 
                         if source.requires_changes(new) {
                             change_partitions.push(PartitionChange {
-                                num: source.number,
-                                start: new.start_sector,
-                                end: new.end_sector,
+                                num:    source.number,
+                                start:  new.start_sector,
+                                end:    new.end_sector,
                                 format: if new.format {
                                     new.filesystem
                                 } else {
                                     None
                                 },
-                                flags: flags_diff(&source.flags, new.flags.clone().into_iter()),
+                                flags:  flags_diff(&source.flags, new.flags.clone().into_iter()),
                             });
                         }
 
@@ -597,10 +598,10 @@ impl Disk {
 
             create_partitions.push(PartitionCreate {
                 start_sector: partition.start_sector,
-                end_sector: partition.end_sector,
-                file_system: partition.filesystem.unwrap(),
-                kind: partition.part_type,
-                flags: partition.flags.clone(),
+                end_sector:   partition.end_sector,
+                file_system:  partition.filesystem.unwrap(),
+                kind:         partition.part_type,
+                flags:        partition.flags.clone(),
             });
         }
 
@@ -647,17 +648,13 @@ impl Disk {
         Ok(())
     }
 
-    pub fn path(&self) -> &Path {
-        &self.device_path
-    }
+    pub fn path(&self) -> &Path { &self.device_path }
 }
 
 pub struct Disks(pub Vec<Disk>);
 
 impl AsRef<[Disk]> for Disks {
-    fn as_ref(&self) -> &[Disk] {
-        &self.0
-    }
+    fn as_ref(&self) -> &[Disk] { &self.0 }
 }
 
 impl Disks {
@@ -785,9 +782,7 @@ impl IntoIterator for Disks {
     type Item = Disk;
     type IntoIter = ::std::vec::IntoIter<Disk>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
+    fn into_iter(self) -> Self::IntoIter { self.0.into_iter() }
 }
 
 impl FromIterator<Disk> for Disks {
@@ -803,82 +798,82 @@ mod tests {
     fn get_default() -> Disks {
         Disks(vec![
             Disk {
-                model_name: "Test Disk".into(),
-                serial: "Test Disk 123".into(),
+                model_name:  "Test Disk".into(),
+                serial:      "Test Disk 123".into(),
                 device_path: "/dev/sdz".into(),
-                size: 1953525168,
+                size:        1953525168,
                 sector_size: 512,
                 device_type: "TEST".into(),
-                table_type: Some(PartitionTable::Gpt),
-                read_only: false,
-                partitions: vec![
+                table_type:  Some(PartitionTable::Gpt),
+                read_only:   false,
+                partitions:  vec![
                     PartitionInfo {
-                        active: true,
-                        busy: true,
-                        is_source: true,
-                        remove: false,
-                        format: false,
-                        device_path: Path::new("/dev/sdz1").to_path_buf(),
-                        flags: vec![],
-                        mount_point: Some(Path::new("/boot/efi").to_path_buf()),
-                        target: Some(Path::new("/boot/efi").to_path_buf()),
+                        active:       true,
+                        busy:         true,
+                        is_source:    true,
+                        remove:       false,
+                        format:       false,
+                        device_path:  Path::new("/dev/sdz1").to_path_buf(),
+                        flags:        vec![],
+                        mount_point:  Some(Path::new("/boot/efi").to_path_buf()),
+                        target:       Some(Path::new("/boot/efi").to_path_buf()),
                         start_sector: 2048,
-                        end_sector: 1026047,
-                        filesystem: Some(FileSystemType::Fat16),
-                        name: None,
-                        number: 1,
-                        part_type: PartitionType::Primary,
+                        end_sector:   1026047,
+                        filesystem:   Some(FileSystemType::Fat16),
+                        name:         None,
+                        number:       1,
+                        part_type:    PartitionType::Primary,
                     },
                     PartitionInfo {
-                        active: true,
-                        busy: true,
-                        is_source: true,
-                        remove: false,
-                        format: false,
-                        device_path: Path::new("/dev/sdz2").to_path_buf(),
-                        flags: vec![],
-                        mount_point: Some(Path::new("/").to_path_buf()),
-                        target: Some(Path::new("/").to_path_buf()),
+                        active:       true,
+                        busy:         true,
+                        is_source:    true,
+                        remove:       false,
+                        format:       false,
+                        device_path:  Path::new("/dev/sdz2").to_path_buf(),
+                        flags:        vec![],
+                        mount_point:  Some(Path::new("/").to_path_buf()),
+                        target:       Some(Path::new("/").to_path_buf()),
                         start_sector: 1026048,
-                        end_sector: 420456447,
-                        filesystem: Some(FileSystemType::Btrfs),
-                        name: Some("Pop!_OS".into()),
-                        number: 2,
-                        part_type: PartitionType::Primary,
+                        end_sector:   420456447,
+                        filesystem:   Some(FileSystemType::Btrfs),
+                        name:         Some("Pop!_OS".into()),
+                        number:       2,
+                        part_type:    PartitionType::Primary,
                     },
                     PartitionInfo {
-                        active: false,
-                        busy: false,
-                        is_source: true,
-                        remove: false,
-                        format: false,
-                        device_path: Path::new("/dev/sdz3").to_path_buf(),
-                        flags: vec![],
-                        mount_point: None,
-                        target: None,
+                        active:       false,
+                        busy:         false,
+                        is_source:    true,
+                        remove:       false,
+                        format:       false,
+                        device_path:  Path::new("/dev/sdz3").to_path_buf(),
+                        flags:        vec![],
+                        mount_point:  None,
+                        target:       None,
                         start_sector: 420456448,
-                        end_sector: 1936738303,
-                        filesystem: Some(FileSystemType::Ext4),
-                        name: Some("Solus OS".into()),
-                        number: 3,
-                        part_type: PartitionType::Primary,
+                        end_sector:   1936738303,
+                        filesystem:   Some(FileSystemType::Ext4),
+                        name:         Some("Solus OS".into()),
+                        number:       3,
+                        part_type:    PartitionType::Primary,
                     },
                     PartitionInfo {
-                        active: true,
-                        busy: false,
-                        is_source: true,
-                        remove: false,
-                        format: false,
-                        device_path: Path::new("/dev/sdz4").to_path_buf(),
-                        flags: vec![],
-                        mount_point: None,
-                        target: None,
+                        active:       true,
+                        busy:         false,
+                        is_source:    true,
+                        remove:       false,
+                        format:       false,
+                        device_path:  Path::new("/dev/sdz4").to_path_buf(),
+                        flags:        vec![],
+                        mount_point:  None,
+                        target:       None,
                         start_sector: 1936738304,
-                        end_sector: 1953523711,
-                        filesystem: Some(FileSystemType::Swap),
-                        name: None,
-                        number: 4,
-                        part_type: PartitionType::Primary,
+                        end_sector:   1953523711,
+                        filesystem:   Some(FileSystemType::Swap),
+                        name:         None,
+                        number:       4,
+                        part_type:    PartitionType::Primary,
                     },
                 ],
             },
@@ -888,15 +883,15 @@ mod tests {
     fn get_empty() -> Disks {
         Disks(vec![
             Disk {
-                model_name: "Test Disk".into(),
-                serial: "Test Disk 123".into(),
+                model_name:  "Test Disk".into(),
+                serial:      "Test Disk 123".into(),
                 device_path: "/dev/sdz".into(),
-                size: 1953525168,
+                size:        1953525168,
                 sector_size: 512,
                 device_type: "TEST".into(),
-                table_type: Some(PartitionTable::Gpt),
-                read_only: false,
-                partitions: Vec::new(),
+                table_type:  Some(PartitionTable::Gpt),
+                read_only:   false,
+                partitions:  Vec::new(),
             },
         ])
     }
@@ -927,31 +922,31 @@ mod tests {
         assert_eq!(
             source.diff(&new).unwrap(),
             DiskOps {
-                device_path: Path::new("/dev/sdz"),
+                device_path:       Path::new("/dev/sdz"),
                 remove_partitions: vec![1, 2, 4],
                 change_partitions: vec![
                     PartitionChange {
-                        num: 3,
-                        start: 420456448,
-                        end: 420456448 + GIB20,
+                        num:    3,
+                        start:  420456448,
+                        end:    420456448 + GIB20,
                         format: Some(FileSystemType::Xfs),
-                        flags: vec![],
+                        flags:  vec![],
                     },
                 ],
                 create_partitions: vec![
                     PartitionCreate {
                         start_sector: 2048,
-                        end_sector: 1024_000 + 2047,
-                        file_system: FileSystemType::Fat16,
-                        kind: PartitionType::Primary,
-                        flags: vec![],
+                        end_sector:   1024_000 + 2047,
+                        file_system:  FileSystemType::Fat16,
+                        kind:         PartitionType::Primary,
+                        flags:        vec![],
                     },
                     PartitionCreate {
                         start_sector: 1026_048,
-                        end_sector: GIB20 + 1026_047,
-                        file_system: FileSystemType::Ext4,
-                        kind: PartitionType::Primary,
-                        flags: vec![],
+                        end_sector:   GIB20 + 1026_047,
+                        file_system:  FileSystemType::Ext4,
+                        kind:         PartitionType::Primary,
+                        flags:        vec![],
                     },
                 ],
             }

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -757,7 +757,8 @@ impl Disks {
 
         // <file system>  <mount point>  <type>  <options>  <dump>  <pass>
         for entry in fs_entries {
-            fstab.reserve_exact(entry.len() + 6);
+            fstab.reserve_exact(entry.len() + 11);
+            fstab.push("UUID=")
             fstab.push(&entry.uuid);
             fstab.push(" ");
             fstab.push(&entry.mount);

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -758,22 +758,23 @@ impl Disks {
 
         // <file system>  <mount point>  <type>  <options>  <dump>  <pass>
         for entry in fs_entries {
-            fstab.reserve_exact(entry.len() + 11);
+            fstab.reserve_exact(entry.len() + 16);
             fstab.push("UUID=");
             fstab.push(&entry.uuid);
-            fstab.push(" ");
+            fstab.push("  ");
             fstab.push(&entry.mount);
-            fstab.push(" ");
+            fstab.push("  ");
             fstab.push(&entry.fs);
-            fstab.push(" ");
+            fstab.push("  ");
             fstab.push(&entry.options);
-            fstab.push(" ");
+            fstab.push("  ");
             fstab.push(if entry.dump { "1" } else { "0" });
-            fstab.push(" ");
+            fstab.push("  ");
             fstab.push(if entry.pass { "1" } else { "0" });
             fstab.push("\n");
         }
 
+        fstab.shrink_to_fit();
         fstab
     }
 }

--- a/src/disk/mounts.rs
+++ b/src/disk/mounts.rs
@@ -22,7 +22,7 @@ impl Mounts {
             }
 
             mounts.push(MountInfo {
-                device: Path::new(&device).to_path_buf(),
+                device:      Path::new(&device).to_path_buf(),
                 mount_point: Path::new(&fields.next().unwrap()).to_path_buf(),
             })
         }
@@ -38,6 +38,6 @@ impl Mounts {
 }
 
 pub struct MountInfo {
-    device: PathBuf,
+    device:      PathBuf,
     mount_point: PathBuf,
 }

--- a/src/disk/operations.rs
+++ b/src/disk/operations.rs
@@ -1,8 +1,10 @@
-use libparted::{Disk as PedDisk, FileSystemType as PedFileSystemType, Geometry,
-                Partition as PedPartition, PartitionFlag, PartitionType as PedPartitionType};
 use super::*;
-use std::path::Path;
 use format::mkfs;
+use libparted::{
+    Disk as PedDisk, FileSystemType as PedFileSystemType, Geometry, Partition as PedPartition,
+    PartitionFlag, PartitionType as PedPartitionType,
+};
+use std::path::Path;
 
 /// Removes a partition by its ID from the disk.
 fn remove_partition(disk: &mut PedDisk, partition: u32) -> Result<(), DiskError> {
@@ -24,7 +26,7 @@ fn get_partition<'a>(disk: &'a mut PedDisk, part: u32) -> Result<PedPartition<'a
 /// The first state of disk operations, which provides a method for removing partitions.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DiskOps<'a> {
-    pub(crate) device_path: &'a Path,
+    pub(crate) device_path:       &'a Path,
     pub(crate) remove_partitions: Vec<i32>,
     pub(crate) change_partitions: Vec<PartitionChange>,
     pub(crate) create_partitions: Vec<PartitionCreate>,
@@ -62,7 +64,7 @@ impl<'a> DiskOps<'a> {
 
         sync(&mut device)?;
         Ok(ChangePartitions {
-            device_path: self.device_path,
+            device_path:       self.device_path,
             change_partitions: self.change_partitions,
             create_partitions: self.create_partitions,
         })
@@ -71,7 +73,7 @@ impl<'a> DiskOps<'a> {
 
 /// The second state of disk operations, which provides a method for changing partitions.
 pub(crate) struct ChangePartitions<'a> {
-    device_path: &'a Path,
+    device_path:       &'a Path,
     change_partitions: Vec<PartitionChange>,
     create_partitions: Vec<PartitionCreate>,
 }
@@ -172,7 +174,7 @@ impl<'a> ChangePartitions<'a> {
 
         // Proceed to the next state in the machine.
         Ok(CreatePartitions {
-            device_path: self.device_path,
+            device_path:       self.device_path,
             create_partitions: self.create_partitions,
         })
     }
@@ -180,7 +182,7 @@ impl<'a> ChangePartitions<'a> {
 
 /// The final state of disk operations, which provides a method for creating new partitions.
 pub(crate) struct CreatePartitions<'a> {
-    device_path: &'a Path,
+    device_path:       &'a Path,
     create_partitions: Vec<PartitionCreate>,
 }
 

--- a/src/disk/operations.rs
+++ b/src/disk/operations.rs
@@ -94,7 +94,7 @@ impl<'a> ChangePartitions<'a> {
                         match part.set_flag(*flag, true) {
                             Ok(()) => flags_changed = true,
                             Err(_) => {
-                                info!(
+                                error!(
                                     "unable to set {:?} for {}{}",
                                     flag,
                                     self.device_path.display(),
@@ -217,7 +217,7 @@ impl<'a> CreatePartitions<'a> {
                     for &flag in &partition.flags {
                         if part.is_flag_available(flag) {
                             if let Err(_) = part.set_flag(flag, true) {
-                                info!("unable to set {:?}", flag);
+                                error!("unable to set {:?}", flag);
                             }
                         }
                     }

--- a/src/disk/partitions.rs
+++ b/src/disk/partitions.rs
@@ -287,7 +287,7 @@ impl PartitionInfo {
             }
         }
 
-        info!("{}: no UUID associated with device", self.device_path.display());
+        error!("{}: no UUID associated with device", self.device_path.display());
         None
     }
 }

--- a/src/disk/partitions.rs
+++ b/src/disk/partitions.rs
@@ -275,7 +275,10 @@ impl PartitionInfo {
                 return Some(BlockInfo {
                     uuid: uuid_entry.file_name(),
                     mount: self.target.clone().unwrap(),
-                    fs: fs.into(),
+                    fs: match fs.into() {
+                        "fat16" | "fat32" => "vfat",
+                        fs => fs,
+                    },
                     options: fs.get_preferred_options().into(),
                     dump: false,
                     pass: false,

--- a/src/disk/partitions.rs
+++ b/src/disk/partitions.rs
@@ -24,7 +24,7 @@ impl FileSystemType {
     fn get_preferred_options(&self) -> &'static str {
         match *self {
             FileSystemType::Ext4 => "noatime,errors=remount-ro",
-            _ => "default"
+            _ => "default",
         }
     }
 }
@@ -185,22 +185,18 @@ pub struct PartitionInfo {
 
 /// Information that will be used to generate a fstab entry for the given partition.
 pub(crate) struct BlockInfo {
-   pub uuid: OsString,
-   pub mount: PathBuf,
-   pub fs: &'static str,
-   pub options: String,
-   pub dump: bool,
-   pub pass: bool 
+    pub uuid: OsString,
+    pub mount: PathBuf,
+    pub fs: &'static str,
+    pub options: String,
+    pub dump: bool,
+    pub pass: bool,
 }
 
 impl BlockInfo {
     /// The size of the data contained within.
     pub fn len(&self) -> usize {
-        self.uuid.len()
-            + self.mount.as_os_str().len()
-            + self.fs.len()
-            + self.options.len()
-            + 2
+        self.uuid.len() + self.mount.as_os_str().len() + self.fs.len() + self.options.len() + 2
     }
 }
 
@@ -270,8 +266,8 @@ impl PartitionInfo {
             return None;
         }
 
-        let uuid_dir = ::std::fs::read_dir("/dev/disk/by-uuid")
-            .expect("unable to find /dev/disk/by-uuid");
+        let uuid_dir =
+            ::std::fs::read_dir("/dev/disk/by-uuid").expect("unable to find /dev/disk/by-uuid");
 
         for uuid_entry in uuid_dir.filter_map(|entry| entry.ok()) {
             if &uuid_entry.path().canonicalize().unwrap() == &self.device_path {
@@ -283,11 +279,14 @@ impl PartitionInfo {
                     options: fs.get_preferred_options().into(),
                     dump: false,
                     pass: false,
-                })
+                });
             }
         }
 
-        error!("{}: no UUID associated with device", self.device_path.display());
+        error!(
+            "{}: no UUID associated with device",
+            self.device_path.display()
+        );
         None
     }
 }

--- a/src/disk/partitions.rs
+++ b/src/disk/partitions.rs
@@ -23,6 +23,7 @@ pub enum FileSystemType {
 impl FileSystemType {
     fn get_preferred_options(&self) -> &'static str {
         match *self {
+            FileSystemType::Fat16 | FileSystemType::Fat32 => "umask=0077",
             FileSystemType::Ext4 => "noatime,errors=remount-ro",
             _ => "default",
         }

--- a/src/disk/partitions.rs
+++ b/src/disk/partitions.rs
@@ -1,5 +1,5 @@
-use libparted::{Partition, PartitionFlag};
 use super::Mounts;
+use libparted::{Partition, PartitionFlag};
 use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -77,12 +77,12 @@ pub enum PartitionType {
 /// Partition builders are supplied as inputs to `Disk::add_partition`.
 pub struct PartitionBuilder {
     pub(crate) start_sector: u64,
-    pub(crate) end_sector: u64,
-    pub(crate) filesystem: FileSystemType,
-    pub(crate) part_type: PartitionType,
-    pub(crate) name: Option<String>,
-    pub(crate) flags: Vec<PartitionFlag>,
-    pub(crate) mount: Option<PathBuf>,
+    pub(crate) end_sector:   u64,
+    pub(crate) filesystem:   FileSystemType,
+    pub(crate) part_type:    PartitionType,
+    pub(crate) name:         Option<String>,
+    pub(crate) flags:        Vec<PartitionFlag>,
+    pub(crate) mount:        Option<PathBuf>,
 }
 
 impl PartitionBuilder {
@@ -90,12 +90,12 @@ impl PartitionBuilder {
     pub fn new(start: u64, end: u64, fs: FileSystemType) -> PartitionBuilder {
         PartitionBuilder {
             start_sector: start,
-            end_sector: end - 1,
-            filesystem: fs,
-            part_type: PartitionType::Primary,
-            name: None,
-            flags: Vec::new(),
-            mount: None,
+            end_sector:   end - 1,
+            filesystem:   fs,
+            part_type:    PartitionType::Primary,
+            name:         None,
+            flags:        Vec::new(),
+            mount:        None,
         }
     }
 
@@ -121,21 +121,21 @@ impl PartitionBuilder {
 
     pub fn build(self) -> PartitionInfo {
         PartitionInfo {
-            is_source: false,
-            remove: false,
-            format: true,
-            active: false,
-            busy: false,
-            number: -1,
+            is_source:    false,
+            remove:       false,
+            format:       true,
+            active:       false,
+            busy:         false,
+            number:       -1,
             start_sector: self.start_sector,
-            end_sector: self.end_sector,
-            part_type: self.part_type,
-            filesystem: Some(self.filesystem),
-            flags: self.flags,
-            name: self.name,
-            device_path: PathBuf::new(),
-            mount_point: None,
-            target: self.mount,
+            end_sector:   self.end_sector,
+            part_type:    self.part_type,
+            filesystem:   Some(self.filesystem),
+            flags:        self.flags,
+            name:         self.name,
+            device_path:  PathBuf::new(),
+            mount_point:  None,
+            target:       self.mount,
         }
     }
 }
@@ -145,7 +145,8 @@ impl PartitionBuilder {
 /// Contains relevant information about a certain partition.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PartitionInfo {
-    /// If set to true, this is a source partition, which means it currently exists on the disk.
+    /// If set to true, this is a source partition, which means it currently exists on the
+    /// disk.
     pub(crate) is_source: bool,
     /// Source partitions will set this field. If set, this partition will be removed.
     pub(crate) remove: bool,
@@ -185,12 +186,12 @@ pub struct PartitionInfo {
 
 /// Information that will be used to generate a fstab entry for the given partition.
 pub(crate) struct BlockInfo {
-    pub uuid: OsString,
-    pub mount: PathBuf,
-    pub fs: &'static str,
+    pub uuid:    OsString,
+    pub mount:   PathBuf,
+    pub fs:      &'static str,
     pub options: String,
-    pub dump: bool,
-    pub pass: bool,
+    pub dump:    bool,
+    pub pass:    bool,
 }
 
 impl BlockInfo {
@@ -241,9 +242,7 @@ impl PartitionInfo {
             .map_or(false, |fs| fs == FileSystemType::Swap)
     }
 
-    pub fn path(&self) -> &Path {
-        &self.device_path
-    }
+    pub fn path(&self) -> &Path { &self.device_path }
 
     pub(crate) fn requires_changes(&self, other: &PartitionInfo) -> bool {
         self.sectors_differ_from(other) || self.filesystem != other.filesystem
@@ -257,9 +256,7 @@ impl PartitionInfo {
         self.is_source && other.is_source && self.number == other.number
     }
 
-    pub fn set_mount(&mut self, target: PathBuf) {
-        self.target = Some(target);
-    }
+    pub fn set_mount(&mut self, target: PathBuf) { self.target = Some(target); }
 
     pub(crate) fn get_block_info(&self) -> Option<BlockInfo> {
         if self.target.is_none() || self.filesystem.is_none() {
@@ -273,15 +270,15 @@ impl PartitionInfo {
             if &uuid_entry.path().canonicalize().unwrap() == &self.device_path {
                 let fs = self.filesystem.unwrap();
                 return Some(BlockInfo {
-                    uuid: uuid_entry.file_name(),
-                    mount: self.target.clone().unwrap(),
-                    fs: match fs.into() {
+                    uuid:    uuid_entry.file_name(),
+                    mount:   self.target.clone().unwrap(),
+                    fs:      match fs.into() {
                         "fat16" | "fat32" => "vfat",
                         fs => fs,
                     },
                     options: fs.get_preferred_options().into(),
-                    dump: false,
-                    pass: false,
+                    dump:    false,
+                    pass:    false,
                 });
             }
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,7 @@
+use super::FileSystemType;
 use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
 use std::process::{Command, Stdio};
-use super::FileSystemType;
 
 pub fn mkfs<P: AsRef<Path>>(part: P, kind: FileSystemType) -> Result<()> {
     let part = part.as_ref();

--- a/src/format.rs
+++ b/src/format.rs
@@ -17,14 +17,14 @@ pub fn mkfs<P: AsRef<Path>>(part: P, kind: FileSystemType) -> Result<()> {
         FileSystemType::Fat32 => ("mkfs.fat", &["-F", "32"]),
         FileSystemType::Ntfs => ("mkfs.ntfs", &["-F", "-q"]),
         FileSystemType::Swap => ("mkswap", &["-f"]),
-        FileSystemType::Xfs => ("mkfs.xfs", &["-f"])
+        FileSystemType::Xfs => ("mkfs.xfs", &["-f"]),
     };
 
     let mut command = Command::new(cmd);
     command.arg(part);
     for arg in args {
-		command.arg(arg);
-	}
+        command.arg(arg);
+    }
 
     debug!("{:?}", command);
 
@@ -37,7 +37,7 @@ pub fn mkfs<P: AsRef<Path>>(part: P, kind: FileSystemType) -> Result<()> {
     } else {
         Err(Error::new(
             ErrorKind::Other,
-            format!("mkfs for {:?} failed with status: {}", kind, status)
+            format!("mkfs for {:?} failed with status: {}", kind, status),
         ))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,5 +576,3 @@ impl Installer {
             .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)))
     }
 }
-
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,18 @@ extern crate tempdir;
 
 use tempdir::TempDir;
 
-use std::collections::BTreeMap;
 use std::{fs, io};
+use std::collections::BTreeMap;
 use std::io::{BufRead, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-pub use disk::{Bootloader, Disk, DiskError, Disks, FileSystemType, PartitionBuilder,
-               PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector};
 pub use chroot::Chroot;
+pub use disk::{
+    Bootloader, Disk, DiskError, Disks, FileSystemType, PartitionBuilder, PartitionFlag,
+    PartitionInfo, PartitionTable, PartitionType, Sector,
+};
 pub use mount::{Mount, MountOption};
 
 #[doc(hidden)]
@@ -73,27 +75,27 @@ pub enum Step {
 #[derive(Debug)]
 pub struct Config {
     pub squashfs: String,
-    pub lang: String,
-    pub remove: String,
+    pub lang:     String,
+    pub remove:   String,
 }
 
 /// Installer error
 #[derive(Debug)]
 pub struct Error {
     pub step: Step,
-    pub err: io::Error,
+    pub err:  io::Error,
 }
 
 /// Installer status
 #[derive(Copy, Clone, Debug)]
 pub struct Status {
-    pub step: Step,
+    pub step:    Step,
     pub percent: i32,
 }
 
 /// An installer object
 pub struct Installer {
-    error_cb: Option<Box<FnMut(&Error)>>,
+    error_cb:  Option<Box<FnMut(&Error)>>,
     status_cb: Option<Box<FnMut(&Status)>>,
 }
 
@@ -106,7 +108,7 @@ impl Installer {
     /// ```
     pub fn new() -> Installer {
         Installer {
-            error_cb: None,
+            error_cb:  None,
             status_cb: None,
         }
     }
@@ -114,12 +116,12 @@ impl Installer {
     /// Send an error message
     ///
     /// ```
+    /// use distinst::{Error, Installer, Step};
     /// use std::io;
-    /// use distinst::{Installer, Error, Step};
     /// let mut installer = Installer::new();
     /// installer.emit_error(&Error {
     ///     step: Step::Extract,
-    ///     err: io::Error::new(io::ErrorKind::NotFound, "File not found")
+    ///     err:  io::Error::new(io::ErrorKind::NotFound, "File not found"),
     /// });
     /// ```
     pub fn emit_error(&mut self, error: &Error) {
@@ -145,7 +147,7 @@ impl Installer {
     /// use distinst::{Installer, Status, Step};
     /// let mut installer = Installer::new();
     /// installer.emit_status(&Status {
-    ///     step: Step::Extract,
+    ///     step:    Step::Extract,
     ///     percent: 50,
     /// });
     /// ```
@@ -298,7 +300,7 @@ impl Installer {
             );
 
             mounts.push(Mount::new(&device_path, &target_mount, &[])?);
-            
+
             info!(
                 "distinst: mounted {} to {}",
                 device_path.display(),
@@ -474,7 +476,7 @@ impl Installer {
         info!("Installing {:?} with {:?}", config, bootloader);
 
         let mut status = Status {
-            step: Step::Init,
+            step:    Step::Init,
             percent: 0,
         };
         self.emit_status(&status);
@@ -488,7 +490,7 @@ impl Installer {
                 error!("initialize: {}", err);
                 let error = Error {
                     step: status.step,
-                    err: err,
+                    err:  err,
                 };
                 self.emit_error(&error);
                 return Err(error.err);
@@ -507,7 +509,7 @@ impl Installer {
             error!("partition: {}", err);
             let error = Error {
                 step: status.step,
-                err: err,
+                err:  err,
             };
             self.emit_error(&error);
             return Err(error.err);
@@ -534,7 +536,7 @@ impl Installer {
             error!("extract: {}", err);
             let error = Error {
                 step: status.step,
-                err: err,
+                err:  err,
             };
             self.emit_error(&error);
             return Err(error.err);
@@ -559,7 +561,7 @@ impl Installer {
             error!("configure: {}", err);
             let error = Error {
                 step: status.step,
-                err: err,
+                err:  err,
             };
             self.emit_error(&error);
             return Err(error.err);
@@ -577,7 +579,7 @@ impl Installer {
             error!("bootloader: {}", err);
             let error = Error {
                 step: status.step,
-                err: err,
+                err:  err,
             };
             self.emit_error(&error);
             return Err(error.err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,13 @@ extern crate tempdir;
 
 use tempdir::TempDir;
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 use std::{fs, io};
 use std::io::{BufRead, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use partition::blockdev;
 pub use disk::{Bootloader, Disk, DiskError, Disks, FileSystemType, PartitionBuilder,
                PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector};
 pub use chroot::Chroot;
@@ -175,7 +174,16 @@ impl Installer {
         info!("Initializing");
 
         let squashfs = match Path::new(&config.squashfs).canonicalize() {
-            Ok(squashfs) => squashfs,
+            Ok(squashfs) => if squashfs.exists() {
+                info!("config.squashfs: found at {}", squashfs.display());
+                squashfs
+            } else {
+                error!("config.squashfs: supplied file does not exist");
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "invalid squashfs path",
+                ));
+            },
             Err(err) => {
                 error!("config.squashfs: {}", err);
                 return Err(err);
@@ -247,9 +255,6 @@ impl Installer {
             info!("{}: Committing changes to disk", disk.path().display());
             disk.commit()
                 .map_err(|why| io::Error::new(io::ErrorKind::Other, format!("{}", why)))?;
-
-            info!("{}: Rereading partition table", disk.path().display());
-            blockdev(&disk.path(), &["--flushbufs", "--rereadpt"])?;
             callback(100);
         }
 
@@ -266,32 +271,39 @@ impl Installer {
 
         let mut mounts = Vec::new();
 
-        // Target paths will be stored in a `BTreeSet` so that mounts are
-        // mounted in the correct order.
-        let mut paths = BTreeSet::new();
+        // The mount path will actually consist of the target concatenated with the root.
+        // NOTE: It is assumed that the target is an absolute path.
+        let paths: BTreeMap<String, PathBuf> = targets
+            .map(|target| {
+                let target_path = target.target.as_ref().unwrap();
+                let target_mount =
+                    [chroot, target_path.to_string_lossy().to_string().as_str()].concat();
 
-        for target in targets {
-            // The mount path will actually consist of the target concatenated with the root.
-            // NOTE: It is assumed that the target is an absolute path.
-            let target_mount = [
-                chroot,
-                target
-                    .target
-                    .as_ref()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string()
-                    .as_str(),
-            ].concat();
+                (target_mount, target.device_path.clone())
+            })
+            .collect();
 
-            mounts.push(Mount::new(&target.device_path, &target_mount, &[])?);
-            paths.insert(target_mount);
-        }
-
-        for target_mount in paths {
+        // Each mount directory will be created and then mounted before progressing to the next
+        // mount in the map. The BTreeMap that the mount targets were collected into
+        // will ensure that mounts are created and mounted in the correct order.
+        for (target_mount, device_path) in paths {
             if let Err(why) = fs::create_dir_all(&target_mount) {
                 error!("unable to create '{}': {}", why, target_mount);
             }
+
+            info!(
+                "distinst: mounting {} to {}",
+                device_path.display(),
+                target_mount
+            );
+
+            mounts.push(Mount::new(&device_path, &target_mount, &[])?);
+            
+            info!(
+                "distinst: mounted {} to {}",
+                device_path.display(),
+                target_mount
+            );
         }
 
         Ok(mounts)
@@ -303,7 +315,6 @@ impl Installer {
         callback: F,
     ) -> io::Result<()> {
         info!("distinst: Extracting {}", squashfs.as_ref().display());
-
         squashfs::extract(squashfs, mount_dir, callback)?;
 
         Ok(())
@@ -317,6 +328,7 @@ impl Installer {
         remove_pkgs: I,
         mut callback: F,
     ) -> io::Result<()> {
+        info!("distinst: Configuring");
         let mount_dir = mount_dir.as_ref();
         let configure_dir = TempDir::new_in(mount_dir.join("tmp"), "distinst")?;
         let configure = configure_dir.path().join("configure.sh");
@@ -339,7 +351,6 @@ impl Installer {
 
         {
             let mut chroot = Chroot::new(mount_dir)?;
-
             let configure_chroot = configure.strip_prefix(mount_dir).map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -508,8 +519,12 @@ impl Installer {
 
         // Mount the temporary directory, and all of our mount targets.
         const CHROOT_ROOT: &'static str = "distinst";
+        info!(
+            "distinst: mounting temporary chroot directory at {}",
+            CHROOT_ROOT
+        );
         let mount_dir = TempDir::new(CHROOT_ROOT)?;
-        let mounts = Installer::mount(&disks, CHROOT_ROOT)?;
+        let mut mounts = Installer::mount(&disks, CHROOT_ROOT)?;
 
         // Extract the Linux image into the new chroot path
         if let Err(err) = Installer::extract(&squashfs, CHROOT_ROOT, |percent| {
@@ -570,9 +585,8 @@ impl Installer {
 
         // Unmount mounts in reverse to prevent unmount issues.
         for mut mount in mounts.into_iter().rev() {
-            if let Err(why) = mount.unmount(true) {
-                error!("{}: unable to unmount: {}", mount.dest().display(), why);
-            }
+            info!("dropping {}", mount.dest().display());
+            drop(mount);
         }
 
         mount_dir.close()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,8 +330,8 @@ impl Installer {
         remove_pkgs: I,
         mut callback: F,
     ) -> io::Result<()> {
-        info!("distinst: Configuring");
-        let mount_dir = mount_dir.as_ref();
+        let mount_dir = mount_dir.as_ref().canonicalize().unwrap();
+        info!("distinst: Configuring on {}", mount_dir.display());
         let configure_dir = TempDir::new_in(mount_dir.join("tmp"), "distinst")?;
         let configure = configure_dir.path().join("configure.sh");
 
@@ -352,8 +352,8 @@ impl Installer {
         }
 
         {
-            let mut chroot = Chroot::new(mount_dir)?;
-            let configure_chroot = configure.strip_prefix(mount_dir).map_err(|err| {
+            let mut chroot = Chroot::new(&mount_dir)?;
+            let configure_chroot = configure.strip_prefix(&mount_dir).map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::Other,
                     format!("Path::strip_prefix failed: {}", err),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use partition::blockdev;
-pub use disk::{Bootloader, Disk, DiskError, Disks, FileSystemType, PartitionBuilder, PartitionFlag,
-               PartitionInfo, PartitionTable, PartitionType, Sector};
+pub use disk::{Bootloader, Disk, DiskError, Disks, FileSystemType, PartitionBuilder,
+               PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector};
 pub use chroot::Chroot;
 pub use mount::{Mount, MountOption};
 
@@ -95,7 +95,7 @@ pub struct Status {
 /// An installer object
 pub struct Installer {
     error_cb: Option<Box<FnMut(&Error)>>,
-    status_cb: Option<Box<FnMut(&Status)>>
+    status_cb: Option<Box<FnMut(&Status)>>,
 }
 
 impl Installer {
@@ -258,7 +258,9 @@ impl Installer {
 
     /// Mount all target paths defined within the provided `disks` configuration.
     fn mount(disks: &Disks, chroot: &str) -> io::Result<Vec<Mount>> {
-        let targets = disks.as_ref().iter()
+        let targets = disks
+            .as_ref()
+            .iter()
             .flat_map(|disk| disk.partitions.iter())
             .filter(|part| !part.target.is_none());
 
@@ -273,7 +275,13 @@ impl Installer {
             // NOTE: It is assumed that the target is an absolute path.
             let target_mount = [
                 chroot,
-                target.target.as_ref().unwrap().to_string_lossy().to_string().as_str()
+                target
+                    .target
+                    .as_ref()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+                    .as_str(),
             ].concat();
 
             mounts.push(Mount::new(&target.device_path, &target_mount, &[])?);
@@ -287,17 +295,14 @@ impl Installer {
         }
 
         Ok(mounts)
-    } 
+    }
 
     fn extract<P: AsRef<Path>, F: FnMut(i32)>(
         squashfs: P,
         mount_dir: &'static str,
         callback: F,
     ) -> io::Result<()> {
-        info!(
-            "distinst: Extracting {}",
-            squashfs.as_ref().display()
-        );
+        info!("distinst: Extracting {}", squashfs.as_ref().display());
 
         squashfs::extract(squashfs, mount_dir, callback)?;
 
@@ -335,13 +340,12 @@ impl Installer {
         {
             let mut chroot = Chroot::new(mount_dir)?;
 
-            let configure_chroot =
-                configure.strip_prefix(mount_dir).map_err(|err| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Path::strip_prefix failed: {}", err),
-                    )
-                })?;
+            let configure_chroot = configure.strip_prefix(mount_dir).map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Path::strip_prefix failed: {}", err),
+                )
+            })?;
 
             let grub_pkg = match bootloader {
                 Bootloader::Bios => "grub-pc",

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,14 +1,12 @@
-use log::{Log, LogLevel, LogRecord, LogMetadata};
+use log::{Log, LogLevel, LogMetadata, LogRecord};
 
 pub struct Logger<F: Fn(LogLevel, &str) + Send + Sync> {
-    callback: F
+    callback: F,
 }
 
 impl<F: Fn(LogLevel, &str) + Send + Sync> Logger<F> {
     pub fn new(callback: F) -> Logger<F> {
-        Logger {
-            callback: callback
-        }
+        Logger { callback: callback }
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,15 +5,11 @@ pub struct Logger<F: Fn(LogLevel, &str) + Send + Sync> {
 }
 
 impl<F: Fn(LogLevel, &str) + Send + Sync> Logger<F> {
-    pub fn new(callback: F) -> Logger<F> {
-        Logger { callback: callback }
-    }
+    pub fn new(callback: F) -> Logger<F> { Logger { callback: callback } }
 }
 
 impl<F: Fn(LogLevel, &str) + Send + Sync> Log for Logger<F> {
-    fn enabled(&self, _metadata: &LogMetadata) -> bool {
-        true
-    }
+    fn enabled(&self, _metadata: &LogMetadata) -> bool { true }
 
     fn log(&self, record: &LogRecord) {
         if self.enabled(record.metadata()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ fn configure_disk(path: &str) -> Result<Disk, DiskError> {
             disk.mklabel(PartitionTable::Gpt)?;
 
             let mut start = disk.get_sector(Sector::Start);
-            let mut end = disk.get_sector(Sector::Megabyte(512));
+            let mut end = disk.get_sector(Sector::Megabyte(150));
             disk.add_partition(
                 PartitionBuilder::new(start, end, FileSystemType::Fat32)
                     .partition_type(PartitionType::Primary)
@@ -176,7 +176,7 @@ fn configure_disk(path: &str) -> Result<Disk, DiskError> {
                     .set_mount(Path::new("/boot/efi").to_path_buf()),
             )?;
 
-            start = disk.get_sector(Sector::Megabyte(512));
+            start = end;
             end = disk.get_sector(Sector::End);
             disk.add_partition(
                 PartitionBuilder::new(start, end, FileSystemType::Ext4)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ extern crate distinst;
 extern crate pbr;
 
 use clap::{App, Arg};
-use distinst::{Bootloader, Config, Disk, DiskError, Disks, FileSystemType, Installer, PartitionBuilder,
-               PartitionFlag, PartitionTable, PartitionType, Sector, Step};
+use distinst::{Bootloader, Config, Disk, DiskError, Disks, FileSystemType, Installer,
+               PartitionBuilder, PartitionFlag, PartitionTable, PartitionType, Sector, Step};
 use pbr::ProgressBar;
 
 use std::{io, process};

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
     if let Err(err) = distinst::log(|_level, message| {
         println!("{}", message);
     }) {
-        println!("Failed to initialize logging: {}", err);
+        eprintln!("Failed to initialize logging: {}", err);
     }
 
     let squashfs = matches.value_of("squashfs").unwrap();
@@ -81,7 +81,7 @@ fn main() {
                     pb.finish_println("");
                 }
 
-                println!("Error: {:?}", error);
+                eprintln!("Error: {:?}", error);
             });
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,10 @@ extern crate distinst;
 extern crate pbr;
 
 use clap::{App, Arg};
-use distinst::{Bootloader, Config, Disk, DiskError, Disks, FileSystemType, Installer,
-               PartitionBuilder, PartitionFlag, PartitionTable, PartitionType, Sector, Step};
+use distinst::{
+    Bootloader, Config, Disk, DiskError, Disks, FileSystemType, Installer, PartitionBuilder,
+    PartitionFlag, PartitionTable, PartitionType, Sector, Step,
+};
 use pbr::ProgressBar;
 
 use std::{io, process};
@@ -125,8 +127,8 @@ fn main() {
             Disks(vec![disk]),
             &Config {
                 squashfs: squashfs.to_string(),
-                lang: lang.to_string(),
-                remove: remove.to_string(),
+                lang:     lang.to_string(),
+                remove:   remove.to_string(),
             },
         )
     };

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -18,7 +18,11 @@ pub enum MountOption {
 }
 
 impl Mount {
-    pub fn new<P: AsRef<Path>, Q: AsRef<Path>>(source: P, dest: Q, options: &[MountOption]) -> Result<Mount> {
+    pub fn new<P: AsRef<Path>, Q: AsRef<Path>>(
+        source: P,
+        dest: Q,
+        options: &[MountOption],
+    ) -> Result<Mount> {
         let source = source.as_ref().canonicalize()?;
         let dest = dest.as_ref().canonicalize()?;
 
@@ -29,7 +33,7 @@ impl Mount {
             match option {
                 MountOption::Bind => {
                     command.arg("--bind");
-                },
+                }
                 MountOption::Synchronize => {
                     option_strings.push("sync");
                 }
@@ -38,7 +42,7 @@ impl Mount {
 
         option_strings.sort();
         option_strings.dedup();
-        if ! option_strings.is_empty() {
+        if !option_strings.is_empty() {
             command.arg("-o");
             command.arg(option_strings.join(","));
         }
@@ -58,7 +62,7 @@ impl Mount {
         } else {
             Err(Error::new(
                 ErrorKind::Other,
-                format!("mount failed with status: {}", status)
+                format!("mount failed with status: {}", status),
             ))
         }
     }
@@ -80,7 +84,7 @@ impl Mount {
             } else {
                 Err(Error::new(
                     ErrorKind::Other,
-                    format!("umount failed with status: {}", status)
+                    format!("umount failed with status: {}", status),
                 ))
             }
         } else {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -2,6 +2,8 @@ use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// TODO: Maybe create an abstraction for `libc::{m,unm}ount`?
+
 #[derive(Debug)]
 pub struct Mount {
     source: PathBuf,
@@ -84,6 +86,10 @@ impl Mount {
         } else {
             Ok(())
         }
+    }
+
+    pub fn dest(&self) -> &Path {
+        &self.dest
     }
 }
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -3,6 +3,16 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 // TODO: Maybe create an abstraction for `libc::{m,unm}ount`?
+// use libc::{mount, umount};
+// pub unsafe extern "C" fn mount(
+//     src: *const c_char, 
+//     target: *const c_char, 
+//     fstype: *const c_char, 
+//     flags: c_ulong, 
+//     data: *const c_void
+// ) -> c_int
+// 
+// pub unsafe extern "C" fn umount(target: *const c_char) -> c_int
 
 #[derive(Debug)]
 pub struct Mount {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -5,19 +5,19 @@ use std::process::Command;
 // TODO: Maybe create an abstraction for `libc::{m,unm}ount`?
 // use libc::{mount, umount};
 // pub unsafe extern "C" fn mount(
-//     src: *const c_char, 
-//     target: *const c_char, 
-//     fstype: *const c_char, 
-//     flags: c_ulong, 
+//     src: *const c_char,
+//     target: *const c_char,
+//     fstype: *const c_char,
+//     flags: c_ulong,
 //     data: *const c_void
 // ) -> c_int
-// 
+//
 // pub unsafe extern "C" fn umount(target: *const c_char) -> c_int
 
 #[derive(Debug)]
 pub struct Mount {
-    source: PathBuf,
-    dest: PathBuf,
+    source:  PathBuf,
+    dest:    PathBuf,
     mounted: bool,
 }
 
@@ -65,8 +65,8 @@ impl Mount {
         let status = command.status()?;
         if status.success() {
             Ok(Mount {
-                source: source,
-                dest: dest,
+                source:  source,
+                dest:    dest,
                 mounted: true,
             })
         } else {
@@ -102,13 +102,9 @@ impl Mount {
         }
     }
 
-    pub fn dest(&self) -> &Path {
-        &self.dest
-    }
+    pub fn dest(&self) -> &Path { &self.dest }
 }
 
 impl Drop for Mount {
-    fn drop(&mut self) {
-        let _ = self.unmount(true);
-    }
+    fn drop(&mut self) { let _ = self.unmount(true); }
 }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -3,7 +3,10 @@ use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
 use std::process::Command;
 
-pub fn blockdev<P: AsRef<Path>, S: AsRef<OsStr>, I: IntoIterator<Item=S>>(disk: P, args: I) -> Result<()> {
+pub fn blockdev<P: AsRef<Path>, S: AsRef<OsStr>, I: IntoIterator<Item = S>>(
+    disk: P,
+    args: I,
+) -> Result<()> {
     let mut command = Command::new("blockdev");
 
     command.args(args);
@@ -17,7 +20,7 @@ pub fn blockdev<P: AsRef<Path>, S: AsRef<OsStr>, I: IntoIterator<Item=S>>(disk: 
     } else {
         Err(Error::new(
             ErrorKind::Other,
-            format!("blockdev failed with status: {}", status)
+            format!("blockdev failed with status: {}", status),
         ))
     }
 }

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -9,7 +9,11 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 use std::str;
 
-pub fn extract<P: AsRef<Path>, Q: AsRef<Path>, F: FnMut(i32)>(squashfs: P, directory: Q, mut callback: F) -> Result<()> {
+pub fn extract<P: AsRef<Path>, Q: AsRef<Path>, F: FnMut(i32)>(
+    squashfs: P,
+    directory: Q,
+    mut callback: F,
+) -> Result<()> {
     let squashfs = squashfs.as_ref().canonicalize()?;
     let directory = directory.as_ref().canonicalize()?;
 
@@ -24,12 +28,14 @@ pub fn extract<P: AsRef<Path>, Q: AsRef<Path>, F: FnMut(i32)>(squashfs: P, direc
 
     let command = format!(
         "unsquashfs -f -d '{}' '{}'",
-        directory.to_str().ok_or(
-            Error::new(ErrorKind::InvalidData, "Invalid directory path")
-        )?.replace("'", "'\"'\"'"),
-        squashfs.to_str().ok_or(
-            Error::new(ErrorKind::InvalidData, "Invalid squashfs path")
-        )?.replace("'", "'\"'\"'")
+        directory
+            .to_str()
+            .ok_or(Error::new(ErrorKind::InvalidData, "Invalid directory path"))?
+            .replace("'", "'\"'\"'"),
+        squashfs
+            .to_str()
+            .ok_or(Error::new(ErrorKind::InvalidData, "Invalid squashfs path"))?
+            .replace("'", "'\"'\"'")
     );
 
     debug!("{}", command);
@@ -72,7 +78,7 @@ pub fn extract<P: AsRef<Path>, Q: AsRef<Path>, F: FnMut(i32)>(squashfs: P, direc
     } else {
         Err(Error::new(
             ErrorKind::Other,
-            format!("unsquashfs failed with status: {}", status)
+            format!("unsquashfs failed with status: {}", status),
         ))
     }
 }


### PR DESCRIPTION
Users can currently define the target mount point of a partition, but are not yet able to have that information carried over in the install. This PR will aim to implement fstab generation within distinst, where each entry will have a UUID obtained from symlink resolutions in `/dev/disk/by-uuid`, and targets provided by the installer will be written to `/etc/fstab` by distinst.

- [x] Generate fstab in memory
- [x] Mount targets before extracting / chrooting (in the event /etc is on another partition)
- [x] Write generated fstab to disk
- [x] Test changes
