### PR TITLE
Set OEM flags in recovery configuration

### DIFF
--- a/src/disk/external.rs
+++ b/src/disk/external.rs
@@ -547,3 +547,7 @@ impl<'a> Drop for ExternalMount<'a> {
         let _ = exec("umount", None, None, &args);
     }
 }
+
+pub(crate) fn remount_rw<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    exec("mount", None, None, &[path.as_ref().into(), "-o".into(), "remount,rw".into()])
+}

--- a/src/envfile.rs
+++ b/src/envfile.rs
@@ -1,0 +1,49 @@
+use std::fs::File;
+use std::io::{self, BufRead, Cursor, Read, Write};
+use std::path::Path;
+
+pub(crate) struct EnvFile<'a>(&'a Path);
+
+impl<'a> EnvFile<'a> {
+    pub fn new(path: &'a Path) -> EnvFile<'a> {
+        EnvFile(path)
+    }
+
+    pub fn update(&self, key: &str, value: &str) -> io::Result<()> {
+        read(self.0)
+            .and_then(|data| replace_env(data, key, value))
+            .and_then(|ref new_data| write(self.0, new_data))
+    }
+
+    pub fn exists(&self) -> bool { self.0.exists() }
+}
+
+fn replace_env(buffer: Vec<u8>, key: &str, value: &str) -> io::Result<Vec<u8>> {
+    let mut new_buffer = Vec::with_capacity(buffer.len());
+    for line in Cursor::new(buffer).lines() {
+        let line = line?;
+        if line.starts_with(&[key, "="].concat()) {
+            new_buffer.extend_from_slice(key.as_bytes());
+            new_buffer.push(b'=');
+            new_buffer.extend_from_slice(value.as_bytes());
+        } else {
+            new_buffer.extend_from_slice(line.as_bytes());
+        }
+        new_buffer.push(b'\n');
+    }
+
+    Ok(new_buffer)
+}
+
+// TODO: These will be no longer be required once Rust is updated in the repos to 1.26.0
+
+fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
+    File::open(path).and_then(|mut file| {
+        let mut buffer = Vec::with_capacity(file.metadata().ok().map_or(0, |x| x.len()) as usize);
+        file.read_to_end(&mut buffer).map(|_| buffer)
+    })
+}
+
+fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
+    File::create(path).and_then(|mut file| file.write_all(contents.as_ref()))
+}

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -101,6 +101,10 @@ then
 
     # Copy casper to special path
     cp -rv "/cdrom/casper" "/recovery/${CASPER}"
+    #
+    # # Make a note that the device is a recovery partition
+    # # The installer will check for this file's existence.
+    # touch "/recovery/recovery"
 
     # Create configuration file
     cat > "/recovery/recovery.conf" << EOF
@@ -112,6 +116,7 @@ KBD_VARIANT=${KBD_VARIANT}
 EFI_UUID=${EFI_UUID}
 RECOVERY_UUID=${RECOVERY_UUID}
 ROOT_UUID=${ROOT_UUID}
+OEM_MODE=0
 EOF
 
     # Copy initrd and vmlinuz to EFI partition


### PR DESCRIPTION
- Modifies the `configure.sh` file to add `OEM_MODE=0`
- If `/cdrom/recovery.conf` exists, remount `/cdrom` with the `rw` option
- Then update the value of `OEM_MODE` to `0`
- And also update the value of `ROOT_UUID` to the new value

This code has not yet been tested.