### PR TITLE
Improve os-release support

### DIFF
--- a/src/disk/config/partitions/os_detect.rs
+++ b/src/disk/config/partitions/os_detect.rs
@@ -91,10 +91,11 @@ fn find_linux_home(base: &Path) -> Option<PathBuf> {
 }
 
 fn detect_linux(base: &Path) -> Option<String> {
-    File::open(base.join("etc/os-release"))
-        .ok()
-        .and_then(|file| ::os_release::parse(BufReader::new(file)))
-        .or_else(|| base.join("etc").exists().map(|| "Unknown Linux".into()))
+    if base.join("etc/os-release").exists() {
+        Some(::os_release::OS_RELEASE.pretty_name.clone())
+    } else {
+        None
+    }
 }
 
 fn detect_windows(base: &Path) -> Option<String> {

--- a/src/hardware_support/mod.rs
+++ b/src/hardware_support/mod.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use raw_cpuid::CpuId;
 use std::io::Read;
+use os_release::OS_RELEASE;
 
 #[macro_use]
 mod macros;
@@ -20,8 +21,7 @@ package!(system76_driver {
 });
 
 pub fn append_packages(install_pkgs: &mut Vec<&'static str>) {
-    // TODO: Obtain this from the environment.
-    let distro = "debian";
+    let distro = OS_RELEASE.id_like.as_str();
 
     append_packages!(install_pkgs, distro => {
         processor_support,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, Permissions};
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, Read, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::PermissionsExt;
@@ -50,7 +50,7 @@ mod envfile;
 pub mod hostname;
 pub mod locale;
 mod logger;
-mod os_release;
+pub mod os_release;
 mod squashfs;
 
 use envfile::EnvFile;
@@ -745,9 +745,6 @@ impl Installer {
 
                         if config.flags & MODIFY_BOOT_ORDER != 0 {
                             let efi_part_num = efi_part_num.to_string();
-                            let os_name = os_release::parse(BufReader::new(File::open("/etc/os-release")?))
-                                .unwrap_or("Linux Boot Manager (systemd-boot)".into());
-
                             let args: &[&OsStr] = &[
                                 "--create".as_ref(),
                                 "--disk".as_ref(),
@@ -756,7 +753,7 @@ impl Installer {
                                 efi_part_num.as_ref(),
                                 "--write-signature".as_ref(),
                                 "--label".as_ref(),
-                                os_name.as_ref(),
+                                os_release::OS_RELEASE.pretty_name.as_ref(),
                                 "--loader".as_ref(),
                                 "\\EFI\\systemd\\systemd-bootx64.efi".as_ref(),
                             ][..];

--- a/src/os_release.rs
+++ b/src/os_release.rs
@@ -1,9 +1,107 @@
-use std::io::BufRead;
+use std::io::{self, BufRead, BufReader};
+use std::fs::File;
 
-pub fn parse<R: BufRead>(file: R) -> Option<String> {
-    const FIELD: &str = "PRETTY_NAME=";
-    file.lines()
-        .flat_map(|line| line)
-        .find(|line| line.starts_with(FIELD))
-        .map(|line| line[FIELD.len() + 1..line.len() - 1].into())
+lazy_static! {
+    pub static ref OS_RELEASE: OsRelease = OsRelease::new()
+        .expect("unable to find /etc/os-release");
+}
+
+macro_rules! starts_with_match {
+    ($item:expr, { $($pat:expr => $field:expr),+ }) => {{
+        $(
+            if $item.starts_with($pat) {
+                $field = parse_line($item, $pat.len()).into();
+                continue;
+            }
+        )+
+    }};
+}
+
+fn parse_line(line: &str, skip: usize) -> &str {
+    let line = line[skip..].trim();
+    if line.starts_with('"') && line.ends_with('"') {
+        &line[1.. line.len() - 1]
+    } else {
+        line
+    }
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct OsRelease {
+    pub name: String,
+    pub version: String,
+    pub id: String,
+    pub id_like: String,
+    pub pretty_name: String,
+    pub version_id: String,
+    pub home_url: String,
+    pub support_url: String,
+    pub bug_report_url: String,
+    pub privacy_policy_url: String,
+    pub version_codename: String,
+}
+
+impl OsRelease {
+    pub fn from_iter<I: Iterator<Item = String>>(lines: I) -> OsRelease {
+        let mut os_release = OsRelease::default();
+
+        for line in lines {
+            starts_with_match!(line.as_str(), {
+                "NAME=" => os_release.name,
+                "VERSION=" => os_release.version,
+                "ID=" => os_release.id,
+                "ID_LIKE=" => os_release.id_like,
+                "PRETTY_NAME=" => os_release.pretty_name,
+                "VERSION_ID=" => os_release.version_id,
+                "HOME_URL=" => os_release.home_url,
+                "SUPPORT_URL=" => os_release.support_url,
+                "BUG_REPORT_URL=" => os_release.bug_report_url,
+                "PRIVACY_POLICY_URL=" => os_release.privacy_policy_url,
+                "VERSION_CODENAME=" => os_release.version_codename
+            });
+        }
+
+        os_release
+    }
+
+    pub fn new() -> io::Result<OsRelease> {
+        let file = BufReader::new(File::open("/etc/os-release")?);
+        Ok(OsRelease::from_iter(file.lines().flat_map(|line| line)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXAMPLE: &str = r#"NAME="Pop!_OS"
+VERSION="18.04 LTS"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Pop!_OS 18.04 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://system76.com/pop"
+SUPPORT_URL="http://support.system76.com"
+BUG_REPORT_URL="https://github.com/pop-os/pop/issues"
+PRIVACY_POLICY_URL="https://system76.com/privacy"
+VERSION_CODENAME=bionic"#;
+
+    #[test]
+    fn os_release() {
+        let os_release = OsRelease::from_iter(EXAMPLE.lines().map(|x| x.into()));
+
+        assert_eq!(os_release, OsRelease {
+            name: "Pop!_OS".into(),
+            version: "18.04 LTS".into(),
+            id: "ubuntu".into(),
+            id_like: "debian".into(),
+            pretty_name: "Pop!_OS 18.04 LTS".into(),
+            version_id: "18.04".into(),
+            home_url: "https://system76.com/pop".into(),
+            support_url: "http://support.system76.com".into(),
+            bug_report_url: "https://github.com/pop-os/pop/issues".into(),
+            privacy_policy_url: "https://system76.com/privacy".into(),
+            version_codename: "bionic".into()
+        })
+    }
 }


### PR DESCRIPTION
This should make it easier to get information about the current Linux environment.
This will also determine the names of hardware packages to install based on the `ID_LIKE` field.
Although only debian-like systems will return packages for hardware at the moment.