### PR TITLE
unwrap() -> expect()

### DIFF
--- a/src/disk/config/disk.rs
+++ b/src/disk/config/disk.rs
@@ -132,7 +132,7 @@ impl Disk {
         });
 
         // TODO: Optimize this so it's not called for each disk.
-        let mounts = Mounts::new().unwrap();
+        let mounts = Mounts::new().expect("failed to get mounts in Disk::new");
 
         Ok(Disk {
             model_name,
@@ -219,9 +219,9 @@ impl Disk {
                 "/sys/class/block/",
                 self.get_device_path()
                     .file_name()
-                    .unwrap()
+                    .expect("no file name found for device")
                     .to_str()
-                    .unwrap(),
+                    .expect("device file name is not UTF-8"),
             ].concat(),
         );
 
@@ -273,7 +273,8 @@ impl Disk {
         );
 
         let mut mounts = BTreeSet::new();
-        let mountstab = Mounts::new().unwrap();
+        let mountstab = Mounts::new()
+            .expect("failed to get mounts in unmount_all_partitions_with_target");
 
         for partition in &mut self.partitions {
             if let Some(ref target) = partition.target {
@@ -408,7 +409,8 @@ impl Disk {
 
         // Ensure that the new dimensions are not overlapping.
         if let Some(id) = self.overlaps_region_excluding(start, end, num) {
-            let partition = self.get_partition_mut(partition).unwrap();
+            let partition = self.get_partition_mut(partition)
+                .expect("unable to find partition that should exist");
             partition.end_sector = backup;
             return Err(DiskError::SectorOverlaps { id });
         }
@@ -444,7 +446,8 @@ impl Disk {
             return Err(DiskError::SectorOverlaps { id });
         }
 
-        let partition = self.get_partition_mut(partition).unwrap();
+        let partition = self.get_partition_mut(partition)
+            .expect("unable to find partition that should exist");
 
         partition.start_sector = start;
         partition.end_sector = end;
@@ -672,7 +675,8 @@ impl Disk {
                                         start_sector: new.start_sector,
                                         end_sector:   new.end_sector,
                                         format:       true,
-                                        file_system:  Some(new.filesystem.clone().unwrap()),
+                                        file_system:  Some(new.filesystem.clone()
+                                            .expect("no file system in partition that requires changes")),
                                         kind:         new.part_type,
                                         flags:        new.flags.clone(),
                                         label:        new.name.clone(),
@@ -720,7 +724,8 @@ impl Disk {
                 start_sector: partition.start_sector,
                 end_sector:   partition.end_sector,
                 format:       true,
-                file_system:  Some(partition.filesystem.clone().unwrap()),
+                file_system:  Some(partition.filesystem.clone()
+                    .expect("no filesystem in partition that is being created")),
                 kind:         partition.part_type,
                 flags:        partition.flags.clone(),
                 label:        partition.name.clone(),

--- a/src/disk/config/disk_trait.rs
+++ b/src/disk/config/disk_trait.rs
@@ -67,11 +67,11 @@ pub trait DiskExt {
             PathBuf::from(match path.read_link() {
                 Ok(resolved) => [
                     "/sys/class/block/",
-                    resolved.file_name().unwrap().to_str().unwrap(),
+                    resolved.file_name().expect("drive does not have a file name").to_str().unwrap(),
                 ].concat(),
                 _ => [
                     "/sys/class/block/",
-                    path.file_name().unwrap().to_str().unwrap(),
+                    path.file_name().expect("drive does not have a file name").to_str().unwrap(),
                 ].concat(),
             })
         };

--- a/src/disk/config/lvm/deactivate.rs
+++ b/src/disk/config/lvm/deactivate.rs
@@ -6,8 +6,8 @@ use std::io;
 use std::path::Path;
 
 pub(crate) fn deactivate_devices<P: AsRef<Path>>(devices: &[P]) -> io::Result<()> {
-    let mounts = Mounts::new().unwrap();
-    let swaps = Swaps::new().unwrap();
+    let mounts = Mounts::new().expect("failed to get mounts in deactivate_devices");
+    let swaps = Swaps::new().expect("failed to get swaps in deactivate_devices");
     let umount = move |vg: &str| -> io::Result<()> {
         for lv in lvs(vg)? {
             if let Some(mount) = mounts.get_mount_point(&lv) {

--- a/src/disk/config/lvm/detect.rs
+++ b/src/disk/config/lvm/detect.rs
@@ -27,16 +27,16 @@ pub(crate) fn physical_volumes_to_deactivate<P: AsRef<Path>>(paths: &[P]) -> Vec
         if let Ok(path) = read_link(pv) {
             let slave_path = concat_osstr(&[
                 "/sys/block/".as_ref(),
-                path.file_name().unwrap(),
+                path.file_name().expect("pv does not have file name"),
                 "/slaves".as_ref(),
             ]);
 
             let _ = read_dirs(&slave_path, |slave| {
                 let slave_path = slave.path();
-                let slave_path = slave_path.file_name().unwrap();
+                let slave_path = slave_path.file_name().expect("slave path does not have file name");
                 if paths
                     .iter()
-                    .any(|p| p.as_ref().file_name().unwrap() == slave_path)
+                    .any(|p| p.as_ref().file_name().expect("slave path does not have file name") == slave_path)
                 {
                     info!("libdistinst: marking to deactivate {}", pv.display());
                     discovered.push(pv.to_path_buf());

--- a/src/disk/config/partitions/mod.rs
+++ b/src/disk/config/partitions/mod.rs
@@ -158,7 +158,9 @@ pub struct PartitionInfo {
 
 impl PartitionInfo {
     pub fn new_from_ped(partition: &Partition) -> io::Result<Option<PartitionInfo>> {
-        let device_path = partition.get_path().unwrap().to_path_buf();
+        let device_path = partition.get_path()
+            .expect("unable to get path from ped partition")
+            .to_path_buf();
         info!(
             "libdistinst: obtaining partition information from {}",
             device_path.display()
@@ -338,13 +340,14 @@ impl PartitionInfo {
         }
 
         let result = get_uuid(&self.device_path).map(|uuid| {
-            let fs = self.filesystem.clone().unwrap();
+            let fs = self.filesystem.clone()
+                .expect("unable to get block info due to lack of file system");
             BlockInfo {
                 uuid,
                 mount: if fs == FileSystemType::Swap {
                     None
                 } else {
-                    Some(self.target.clone().unwrap())
+                    Some(self.target.clone().expect("unable to get block info due to lack of target"))
                 },
                 fs: match fs {
                     FileSystemType::Fat16 | FileSystemType::Fat32 => "vfat",

--- a/src/disk/external.rs
+++ b/src/disk/external.rs
@@ -93,7 +93,7 @@ pub(crate) fn dmlist() -> io::Result<Vec<String>> {
             .stderr(Stdio::null())
             .spawn()?
             .stdout
-            .unwrap(),
+            .expect("failed to execute dmsetup command"),
     );
 
     // Skip the first line of output
@@ -432,7 +432,7 @@ pub(crate) fn lvs(vg: &str) -> io::Result<Vec<PathBuf>> {
             .stderr(Stdio::null())
             .spawn()?
             .stdout
-            .unwrap(),
+            .expect("failed to execute lvs command"),
     );
 
     // Skip the first line of output
@@ -469,7 +469,7 @@ pub(crate) fn pvs() -> io::Result<BTreeMap<PathBuf, Option<String>>> {
             .stderr(Stdio::null())
             .spawn()?
             .stdout
-            .unwrap(),
+            .expect("failed to execute pvs command"),
     );
 
     // Skip the first line of output

--- a/src/disk/operations/mod.rs
+++ b/src/disk/operations/mod.rs
@@ -273,7 +273,8 @@ impl<'a> CreatePartitions<'a> {
             // Open a second instance of the disk which we need to get the new partition ID.
             let path = get_partition_id(self.device_path, partition.start_sector as i64)?;
             self.format_partitions
-                .push((path, partition.file_system.clone().unwrap()));
+                .push((path, partition.file_system.clone()
+                    .expect("file system does not exist when creating partition")));
         }
 
         // Attempt to sync three times before returning an error.
@@ -335,7 +336,7 @@ fn create_partition(device: &mut Device, partition: &PartitionCreate) -> Result<
     }
 
     // Add the partition, and commit the changes to the disk.
-    let constraint = geometry.exact().unwrap();
+    let constraint = geometry.exact().expect("exact constraint not found");
     disk.add_partition(&mut part, &constraint)
         .map_err(|why| DiskError::PartitionCreate { why })?;
 
@@ -366,13 +367,13 @@ fn get_partition_and<T, F: FnOnce(PedPartition) -> T>(
 
 fn get_partition_id(path: &Path, start_sector: i64) -> Result<PathBuf, DiskError> {
     get_partition_and(path, start_sector, |part| {
-        part.get_path().unwrap().to_path_buf()
+        part.get_path().expect("ped partition does not have path").to_path_buf()
     })
 }
 
 fn get_partition_id_and_path(path: &Path, start_sector: i64) -> Result<(i32, PathBuf), DiskError> {
     get_partition_and(path, start_sector, |part| {
-        (part.num(), part.get_path().unwrap().to_path_buf())
+        (part.num(), part.get_path().expect("ped partition does not have path").to_path_buf())
     })
 }
 


### PR DESCRIPTION
Replaces most usages of `unwrap()` with `expect()`, to get more information in the event that an option is unwrapped.