### PR TITLE
Fix for logical devices with dashes in names

### DIFF
--- a/src/disk/config/lvm/mod.rs
+++ b/src/disk/config/lvm/mod.rs
@@ -93,7 +93,7 @@ impl LvmDevice {
         sector_size: u64,
         is_source: bool,
     ) -> LvmDevice {
-        let device_path = PathBuf::from(format!("/dev/mapper/{}", volume_group));
+        let device_path = PathBuf::from(format!("/dev/mapper/{}", volume_group.replace("-", "--")));
 
         // TODO: Optimize this so it's not called for each disk.
         let mounts = Mounts::new().expect("unable to get mounts within LvmDevice::new");
@@ -181,7 +181,7 @@ impl LvmDevice {
                 let length = match get_size(&path) {
                     Ok(length) => length,
                     Err(why) => {
-                        eprintln!("unable to get size of LVM device: {}", why);
+                        eprintln!("unable to get size of LVM device {:?}: {}", path, why);
                         0
                     }
                 };

--- a/src/disk/external.rs
+++ b/src/disk/external.rs
@@ -444,7 +444,12 @@ pub(crate) fn lvs(vg: &str) -> io::Result<Vec<PathBuf>> {
             let line = &current_line[2..];
             match line.find(' ') {
                 Some(pos) => output.push(PathBuf::from(
-                    ["/dev/mapper/", vg, "-", &line[..pos]].concat(),
+                    [
+                        "/dev/mapper/",
+                        &vg.replace("-", "--"),
+                        "-",
+                        &(&line[..pos].replace("-", "--"))
+                    ].concat(),
                 )),
                 None => (),
             }


### PR DESCRIPTION
Fixes https://github.com/pop-os/pop/issues/272

Logical devices with dashes in their name will have their paths modified to use two dashes instead of one, although they'll still be referred to by their single dash name within LVM tools. This will fix the device paths to account for that.

- [x] Fix custom partitioning view & detect volume information
- [x] Ability to install onto these devices (requires https://github.com/pop-os/installer/pull/125)

![screenshot from 2018-05-11 09-43-05](https://user-images.githubusercontent.com/4143535/39933268-bcda9c7e-54ff-11e8-8b99-226c75f9215d.png)
