### PR TITLE
Detect nvidia module & append nvidia package

### DIFF
--- a/src/hardware_support/macros.rs
+++ b/src/hardware_support/macros.rs
@@ -1,21 +1,32 @@
 #[macro_export]
 macro_rules! package {
-    ($name:tt { $($distro:expr => $package:expr),+ })  => (
-        fn $name(distro: &str) -> Option<&'static str> {
-            match distro {
-                $($distro => Some($package)),+,
-                _ => None
-            }
+    (name $distro:expr => $package:expr) => {{
+        if OS_RELEASE.name.as_str() == $distro {
+            return Some($package);
         }
-    )
+    }};
+
+    (like $distro:expr => $package:expr) => {{
+        if OS_RELEASE.id_like.as_str() == $distro {
+            return Some($package);
+        }
+    }};
+
+    ($name:tt { $( $field:tt $distro:expr => $package:expr ),+ })  => (
+        fn $name() -> Option<&'static str> {
+            $( package!($field $distro => $package); )+
+
+            None
+        }
+    );
 }
 
 
 #[macro_export]
 macro_rules! append_packages {
-    ($install_pkgs:ident, $distro:expr => { $($detect:tt),+ }) => (
+    ($install_pkgs:ident { $($detect:tt),+ }) => (
         $(
-            if let Some(package) = $detect($distro) {
+            if let Some(package) = $detect() {
                 $install_pkgs.push(package);
             }
         )+
@@ -24,10 +35,10 @@ macro_rules! append_packages {
 
 #[macro_export]
 macro_rules! vendor {
-    ($input:expr, $distro:expr, { $($method:tt $pattern:expr => $func:tt),+ }) => (
+    ($input:expr => { $($method:tt $pattern:expr => $func:tt),+ }) => (
         $(
             if $input.$method($pattern) {
-                return $func($distro);
+                return $func();
             }
         )+
     )

--- a/src/hardware_support/macros.rs
+++ b/src/hardware_support/macros.rs
@@ -12,9 +12,19 @@ macro_rules! package {
         }
     }};
 
-    ($name:tt { $( $field:tt $distro:expr => $package:expr ),+ })  => (
+    (vendor $vendor:expr => $package:expr) => {{
+        if vendor().map_or(false, |vendor| vendor.starts_with($vendor))  {
+            return Some($package);
+        }
+    }};
+
+    ($name:tt { $( $( $field:tt $distro:expr ),+ => $package:expr ),+ })  => (
         fn $name() -> Option<&'static str> {
-            $( package!($field $distro => $package); )+
+            $(
+                $(
+                    package!($field $distro => $package);
+                )+
+            )+
 
             None
         }

--- a/src/hardware_support/mod.rs
+++ b/src/hardware_support/mod.rs
@@ -24,8 +24,7 @@ package!(system76_driver {
 });
 
 package!(nvidia_driver {
-    like "debian", vendor "System76" => "system76-driver-nvidia",
-    like "debian" => "nvidia-driver-390"
+    like "debian", vendor "System76" => "system76-driver-nvidia"
 });
 
 pub fn append_packages(install_pkgs: &mut Vec<&'static str>) {

--- a/src/hardware_support/mod.rs
+++ b/src/hardware_support/mod.rs
@@ -5,36 +5,53 @@ use os_release::OS_RELEASE;
 
 #[macro_use]
 mod macros;
+mod modules;
+
+use self::modules::Module;
 
 // NOTE: Distributions should provide their distro ID and associated packages here, if applicable.
 
 package!(amd_microcode {
-    "debian" => "amd64-microcode"
+    like "debian" => "amd64-microcode"
 });
 
 package!(intel_microcode {
-    "debian" => "intel-microcode"
+    like "debian" => "intel-microcode"
 });
 
 package!(system76_driver {
-    "debian" => "system76-driver"
+    like "debian" => "system76-driver"
+});
+
+package!(nvidia_driver {
+    name "Pop!_OS" => "system76-driver-nvidia",
+    like "debian" => "nvidia-driver-390"
 });
 
 pub fn append_packages(install_pkgs: &mut Vec<&'static str>) {
-    let distro = OS_RELEASE.id_like.as_str();
-
-    append_packages!(install_pkgs, distro => {
+    append_packages!(install_pkgs {
         processor_support,
-        vendor_support
+        vendor_support,
+        graphics_support
     });
 }
 
+fn graphics_support() -> Option<&'static str> {
+    Module::all().ok().and_then(|modules| {
+        if modules.iter().any(|x| &x.name == "nvidia") {
+            return nvidia_driver();
+        }
+
+        None
+    })
+}
+
 /// Microcode packages for specific processor vendors.
-fn processor_support(distro: &str) -> Option<&'static str> {
+fn processor_support() -> Option<&'static str> {
     if let Some(vf) = CpuId::new().get_vendor_info() {
         return match vf.as_string() {
-            "AuthenticAMD" => amd_microcode(distro),
-            "GenuineIntel" => intel_microcode(distro),
+            "AuthenticAMD" => amd_microcode(),
+            "GenuineIntel" => intel_microcode(),
             _ => None
         };
     }
@@ -43,12 +60,12 @@ fn processor_support(distro: &str) -> Option<&'static str> {
 }
 
 /// Hardware enablement packages for hardware from specific vendors.
-fn vendor_support(distro: &str) -> Option<&'static str> {
+fn vendor_support() -> Option<&'static str> {
     if let Ok(mut file) = File::open("/sys/class/dmi/id/sys_vendor") {
         let mut string = String::new();
         if let Ok(_) = file.read_to_string(&mut string) {
             // NOTE: Vendors should add their logic & package names here.
-            vendor!(string.trim(), distro, {
+            vendor!(string.trim() => {
                 starts_with "System76" => system76_driver
             });
         }

--- a/src/hardware_support/mod.rs
+++ b/src/hardware_support/mod.rs
@@ -24,7 +24,7 @@ package!(system76_driver {
 });
 
 package!(nvidia_driver {
-    name "Pop!_OS" => "system76-driver-nvidia",
+    like "debian", vendor "System76" => "system76-driver-nvidia",
     like "debian" => "nvidia-driver-390"
 });
 
@@ -61,15 +61,19 @@ fn processor_support() -> Option<&'static str> {
 
 /// Hardware enablement packages for hardware from specific vendors.
 fn vendor_support() -> Option<&'static str> {
-    if let Ok(mut file) = File::open("/sys/class/dmi/id/sys_vendor") {
-        let mut string = String::new();
-        if let Ok(_) = file.read_to_string(&mut string) {
-            // NOTE: Vendors should add their logic & package names here.
-            vendor!(string.trim() => {
-                starts_with "System76" => system76_driver
-            });
-        }
+    if let Some(vendor) = vendor() {
+        // NOTE: Vendors should add their logic & package names here.
+        vendor!(vendor.trim() => {
+            starts_with "System76" => system76_driver
+        });
     }
 
     None
+}
+
+fn vendor() -> Option<String> {
+    let mut vendor = String::new();
+    File::open("/sys/class/dmi/id/sys_vendor")
+        .and_then(|mut file| file.read_to_string(&mut vendor))
+        .ok().map(|_| vendor)
 }

--- a/src/hardware_support/modules.rs
+++ b/src/hardware_support/modules.rs
@@ -1,0 +1,35 @@
+use std::io::{self, Read};
+use std::fs::File;
+
+pub struct Module {
+    pub name: String,
+}
+
+impl Module {
+    fn parse(line: &str) -> io::Result<Module> {
+        let mut parts = line.split(" ");
+
+        let name = parts.next().ok_or(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "module name not found"
+        ))?;
+
+        Ok(Module {
+            name: name.to_string(),
+        })
+    }
+
+    pub fn all() -> io::Result<Vec<Module>> {
+        let mut modules = Vec::new();
+
+        let mut data = String::new();
+        File::open("/proc/modules").and_then(|mut file| file.read_to_string(&mut data))?;
+
+        for line in data.lines() {
+            let module = Module::parse(line)?;
+            modules.push(module);
+        }
+
+        Ok(modules)
+    }
+}


### PR DESCRIPTION
Detects if the `nvidia` module is loaded, and if so, selects the `system76-driver-nvidia` package for install when the install media has `Pop!_OS` as the `NAME` in `/etc/os-release`. Otherwise, `nvidia-driver-390` for media with an `ID_LIKE` of `debian`.

The package macros were slightly modified to be more flexible, due to Pop!-specific handling.

This compiles, and I have tested it to work.