### PR TITLE
Add FORCE_BIOS Bootloader switch

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,8 +10,9 @@ use clap::{App, Arg, ArgMatches, Values};
 use distinst::{
     Config, Disk, DiskError, DiskExt, Disks, FileSystemType, Installer, LvmEncryption,
     PartitionBuilder, PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector, Step,
-    KILL_SWITCH, PARTITIONING_TEST,
+    KILL_SWITCH, PARTITIONING_TEST, FORCE_BIOS
 };
+
 use pbr::ProgressBar;
 
 use std::cell::RefCell;
@@ -173,6 +174,11 @@ fn main() {
                 .help("simply test whether the provided arguments pass the partitioning stage"),
         )
         .arg(
+            Arg::with_name("force-bios")
+                .long("force-bios")
+                .help("performs a BIOS installation even if the running system is EFI")
+        )
+        .arg(
             Arg::with_name("delete")
                 .short("d")
                 .long("delete")
@@ -295,6 +301,10 @@ fn main() {
         let testing = matches.occurrences_of("test") != 0;
         if testing {
             PARTITIONING_TEST.store(true, Ordering::SeqCst);
+        }
+
+        if matches.occurrences_of("force-bios") != 0 {
+            FORCE_BIOS.store(true, Ordering::SeqCst);
         }
 
         fn take_optional_string(argument: Option<&str>) -> Option<String> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,7 +10,7 @@ use clap::{App, Arg, ArgMatches, Values};
 use distinst::{
     Config, Disk, DiskError, DiskExt, Disks, FileSystemType, Installer, LvmEncryption,
     PartitionBuilder, PartitionFlag, PartitionInfo, PartitionTable, PartitionType, Sector, Step,
-    KILL_SWITCH, PARTITIONING_TEST, FORCE_BIOS
+    KILL_SWITCH, PARTITIONING_TEST, FORCE_BOOTLOADER
 };
 
 use pbr::ProgressBar;
@@ -179,6 +179,11 @@ fn main() {
                 .help("performs a BIOS installation even if the running system is EFI")
         )
         .arg(
+            Arg::with_name("force-efi")
+                .long("force-efi")
+                .help("performs an EFI installation even if the running system is BIOS")
+        )
+        .arg(
             Arg::with_name("delete")
                 .short("d")
                 .long("delete")
@@ -304,7 +309,9 @@ fn main() {
         }
 
         if matches.occurrences_of("force-bios") != 0 {
-            FORCE_BIOS.store(true, Ordering::SeqCst);
+            FORCE_BOOTLOADER.store(1, Ordering::SeqCst);
+        } else if matches.occurrences_of("force-efi") != 0 {
+            FORCE_BOOTLOADER.store(2, Ordering::SeqCst);
         }
 
         fn take_optional_string(argument: Option<&str>) -> Option<String> {

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -15,6 +15,9 @@ pub use self::swaps::Swaps;
 pub use libparted::PartitionFlag;
 use libparted::{Device, DiskType as PedDiskType};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+
+use super::FORCE_BIOS;
 
 /// Bootloader type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -26,6 +29,10 @@ pub enum Bootloader {
 impl Bootloader {
     /// Detects whether the system is running from EFI.
     pub fn detect() -> Bootloader {
+        if FORCE_BIOS.load(Ordering::SeqCst) {
+            return Bootloader::Bios;
+        }
+
         if Path::new("/sys/firmware/efi").is_dir() {
             Bootloader::Efi
         } else {

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -17,7 +17,7 @@ use libparted::{Device, DiskType as PedDiskType};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 
-use super::FORCE_BIOS;
+use super::FORCE_BOOTLOADER;
 
 /// Bootloader type
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -29,8 +29,14 @@ pub enum Bootloader {
 impl Bootloader {
     /// Detects whether the system is running from EFI.
     pub fn detect() -> Bootloader {
-        if FORCE_BIOS.load(Ordering::SeqCst) {
-            return Bootloader::Bios;
+        match FORCE_BOOTLOADER.load(Ordering::SeqCst) {
+            1 => {
+                return Bootloader::Bios;
+            }
+            2 => {
+                return Bootloader::Efi;
+            }
+            _ => ()
         }
 
         if Path::new("/sys/firmware/efi").is_dir() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ use envfile::EnvFile;
 /// When set to true, this will stop the installation process.
 pub static KILL_SWITCH: AtomicBool = ATOMIC_BOOL_INIT;
 
+/// Force the installation to perform a BIOS install, even if on an EFI system.
+pub static FORCE_BIOS: AtomicBool = ATOMIC_BOOL_INIT;
+
 /// Exits before the unsquashfs step
 pub static PARTITIONING_TEST: AtomicBool = ATOMIC_BOOL_INIT;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, ATOMIC_BOOL_INIT, ATOMIC_USIZE_INIT};
 use std::thread::sleep;
 use std::time::Duration;
 use tempdir::TempDir;
@@ -64,8 +64,8 @@ use envfile::EnvFile;
 /// When set to true, this will stop the installation process.
 pub static KILL_SWITCH: AtomicBool = ATOMIC_BOOL_INIT;
 
-/// Force the installation to perform a BIOS install, even if on an EFI system.
-pub static FORCE_BIOS: AtomicBool = ATOMIC_BOOL_INIT;
+/// Force the installation to perform either a BIOS or EFI installation.
+pub static FORCE_BOOTLOADER: AtomicUsize = ATOMIC_USIZE_INIT;
 
 /// Exits before the unsquashfs step
 pub static PARTITIONING_TEST: AtomicBool = ATOMIC_BOOL_INIT;


### PR DESCRIPTION
- The backend will now have a switch that will override `Bootloader::detect()` to return `Bios`.
- The cli now has a `--force-bios` flag that will set this value.

@jackpot51 