### PR TITLE
Automatically create extended partition

### DIFF
--- a/src/disk/config/disk.rs
+++ b/src/disk/config/disk.rs
@@ -3,8 +3,8 @@ use super::super::mounts::Mounts;
 use super::super::operations::*;
 use super::super::serial::get_serial;
 use super::super::{
-    check_partition_size, DiskError, DiskExt, Disks, FileSystemType, PartitionFlag, PartitionInfo,
-    PartitionTable, PartitionType,
+    check_partition_size, DiskError, DiskExt, Disks, FileSystemType, PartitionError, PartitionFlag,
+    PartitionInfo, PartitionTable, PartitionType,
 };
 use super::partitions::{FORMAT, REMOVE, SOURCE, SWAPPED};
 use super::{get_device, open_disk};
@@ -79,20 +79,20 @@ impl DiskExt for Disk {
 
     fn get_table_type(&self) -> Option<PartitionTable> { self.table_type }
 
-    fn validate_partition_table(&self, part_type: PartitionType) -> Result<(), DiskError> {
+    fn validate_partition_table(&self, part_type: PartitionType) -> Result<(), PartitionError> {
         match self.table_type {
             Some(PartitionTable::Gpt) => (),
             Some(PartitionTable::Msdos) => {
                 let (primary, logical) = self.get_partition_type_count();
                 if part_type == PartitionType::Primary {
                     if primary == 4 || (primary == 3 && logical != 0) {
-                        return Err(DiskError::PrimaryPartitionsExceeded);
+                        return Err(PartitionError::PrimaryPartitionsExceeded);
                     }
                 } else if primary == 4 {
-                    return Err(DiskError::PrimaryPartitionsExceeded);
+                    return Err(PartitionError::PrimaryPartitionsExceeded);
                 }
             }
-            None => return Err(DiskError::PartitionTableNotFound),
+            None => return Err(PartitionError::PartitionTableNotFound),
         }
 
         Ok(())

--- a/src/disk/config/lvm/mod.rs
+++ b/src/disk/config/lvm/mod.rs
@@ -10,7 +10,7 @@ use super::super::external::{
 };
 use super::super::mounts::Mounts;
 use super::super::{
-    DiskError, DiskExt, Disks, PartitionInfo, PartitionTable, PartitionType, FORMAT, REMOVE, SOURCE,
+    DiskError, DiskExt, Disks, PartitionError, PartitionInfo, PartitionTable, PartitionType, FORMAT, REMOVE, SOURCE,
 };
 use super::get_size;
 use rand::{self, Rng};
@@ -77,7 +77,7 @@ impl DiskExt for LvmDevice {
 
     fn get_table_type(&self) -> Option<PartitionTable> { None }
 
-    fn validate_partition_table(&self, _part_type: PartitionType) -> Result<(), DiskError> {
+    fn validate_partition_table(&self, _part_type: PartitionType) -> Result<(), PartitionError> {
         Ok(())
     }
 

--- a/src/disk/config/partitions/mod.rs
+++ b/src/disk/config/partitions/mod.rs
@@ -11,7 +11,7 @@ pub use self::os_detect::OS;
 use self::os_detect::detect_os;
 use self::usage::get_used_sectors;
 use super::super::external::{get_label, is_encrypted, pvs};
-use super::super::{LvmEncryption, Mounts, Swaps};
+use super::super::{LvmEncryption, Mounts, Swaps, PartitionError};
 use super::PVS;
 use libparted::{Partition, PartitionFlag};
 use std::io;
@@ -19,11 +19,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use FileSystemType::*;
 use misc::get_uuid;
-
-#[derive(Debug)]
-pub enum PartitionError {
-    ShrinkValueTooHigh,
-}
 
 /// Specifies which file system format to use.
 #[derive(Debug, PartialEq, Copy, Clone, Hash)]

--- a/src/disk/mod.rs
+++ b/src/disk/mod.rs
@@ -9,7 +9,7 @@ mod serial;
 mod swaps;
 
 pub use self::config::*;
-pub use self::error::{DecryptionError, DiskError, PartitionSizeError};
+pub use self::error::{DecryptionError, DiskError, PartitionError, PartitionSizeError};
 pub(crate) use self::mounts::Mounts;
 pub use self::swaps::Swaps;
 pub use libparted::PartitionFlag;

--- a/tests/install-bios.sh
+++ b/tests/install-bios.sh
@@ -38,7 +38,6 @@ sudo target/debug/distinst \
     -n "$1:primary:start:512M:ntfs" \
     -n "$1:primary:512M:51200M:ntfs:mount=/win" \
     -n "$1:primary:51200M:71680M:ext4:mount=/" \
-    -n "$1:extended:71680M:end:none" \
     -n "$1:logical:71682M:102400M:ext4" \
     -n "$1:logical:102400M:-4096M:ext4" \
     -n "$1:logical:-4096M:end:swap"


### PR DESCRIPTION
- When primary partitions have been exceeded, switch them to logical
- If an extended partition does not yet exist, create it automatically

With this change, it will no longer be required to manually specify an extended partition, and it will no longer be required to specify a partition as logical.