### PR TITLE
Don't overwrite swap partitions with swap

### DIFF
--- a/src/disk/config/disk.rs
+++ b/src/disk/config/disk.rs
@@ -667,9 +667,7 @@ impl Disk {
                             }
 
                             if source.requires_changes(new) {
-                                if new.flag_is_enabled(FORMAT)
-                                    || source.filesystem == Some(FileSystemType::Swap)
-                                {
+                                if new.flag_is_enabled(FORMAT) {
                                     remove_partitions.push(source.start_sector);
                                     create_partitions.push(PartitionCreate {
                                         path:         self.device_path.clone(),


### PR DESCRIPTION
- Prevents swap partitions from having their UUIDs changed.
- Useful to prevent UUIDs being changed out in a dual boot configuration.

Tested with the bios-install script, running `lsblk` before and after.

```sh
sudo target/debug/distinst \
    -s "${FS}" \
    -r "${REMOVE}" \
    -h "pop-testing" \
    -k "us" \
    -l "en_US.UTF-8" \
    --force-bios \
    -b "$1" \
    -u "$1:2:ntfs:mount=/win" \
    -u "$1:3:ext4:mount=/" \
    -u "$1:6:ext4:mount=/home" \
    -u "$1:7:swap"
```

Partitions 2, 3, 6, and 7 were marked to be reformatted.

### Before

```
NAME   FSTYPE LABEL              UUID                                 MOUNTPOINT
sdb                                                                   
├─sdb1 ntfs                      264DD6AD20E2DAA7                     
├─sdb2 ntfs                      264DD6AD20E2DAA7                     
├─sdb3 ext4                      4e569c89-710d-459b-af76-919eeb9d70bd 
├─sdb4                                                                
├─sdb5 ext4                      10527e03-6b8f-415c-9964-172f4c8d8cfa 
├─sdb6 ext4                      f98fca94-18f3-42c4-8c6e-c70eda05d414 
└─sdb7 swap                      b9f39c33-8a4b-49ff-9ae7-061b765a51be
```

### After

```
NAME   FSTYPE LABEL              UUID                                 MOUNTPOINT
sdb                                                                   
├─sdb1 ntfs                      264DD6AD20E2DAA7                     
├─sdb2 ntfs                      4B1B089F3FA734FC                     
├─sdb3 ext4                      a84ed41b-b255-4ff7-82a6-e67626309ce8 
├─sdb4                                                                
├─sdb5 ext4                      10527e03-6b8f-415c-9964-172f4c8d8cfa 
├─sdb6 ext4                      dd4e49c3-7faa-4cc2-8f66-0f108e42964e 
└─sdb7 swap                      b9f39c33-8a4b-49ff-9ae7-061b765a51be
```

Note that the swap partition was unchanged.