### PR TITLE
Remove cyclic reference to parent disks

### DIFF
--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -647,7 +647,7 @@ namespace Distinst {
         /**
          * Returns true if the device contains a partition mounted at the specified target.
          */
-        public bool contains_mount (string mount);
+        public bool contains_mount (string mount, Distinst.Disks disks);
 
         /**
          * Returns true if the device is a removable device.
@@ -730,7 +730,7 @@ namespace Distinst {
         /**
          * Returns true if the device contains a partition mounted at the specified target.
          */
-        public bool contains_mount (string mount);
+        public bool contains_mount (string mount, Distinst.Disks disks);
 
         /**
          * Returns a slice of all partitions on this volume.

--- a/ffi/src/disk.rs
+++ b/ffi/src/disk.rs
@@ -115,10 +115,12 @@ pub unsafe extern "C" fn distinst_disk_get_partition_by_path(
 pub unsafe extern "C" fn distinst_disk_contains_mount(
     disk: *const DistinstDisk,
     mount: *const libc::c_char,
+    disks: *const DistinstDisks,
 ) -> bool {
     get_str(mount, "").ok().map_or(false, |mount| {
         let disk = &mut *(disk as *mut Disk);
-        disk.contains_mount(mount)
+        let disks = &*(disks as *const Disks);
+        disk.contains_mount(mount, &*disks)
     })
 }
 

--- a/ffi/src/lvm.rs
+++ b/ffi/src/lvm.rs
@@ -212,10 +212,12 @@ pub unsafe extern "C" fn distinst_lvm_device_list_partitions(
 pub unsafe extern "C" fn distinst_lvm_device_contains_mount(
     disk: *const DistinstLvmDevice,
     mount: *const libc::c_char,
+    disks: *const DistinstDisks,
 ) -> bool {
     get_str(mount, "").ok().map_or(false, |mount| {
         let disk = &mut *(disk as *mut LvmDevice);
-        disk.contains_mount(mount)
+        let disks = &*(disks as *const Disks);
+        disk.contains_mount(mount, &*disks)
     })
 }
 

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -66,11 +66,11 @@ impl InstallOptions {
 
             for device in disks.get_physical_devices() {
                 if !Path::new("/cdrom/recovery.conf").exists() {
-                    if device.contains_mount("/") || device.contains_mount("/cdrom") {
+                    if device.contains_mount("/", &disks) || device.contains_mount("/cdrom", &disks) {
                         continue
                     }
                 }
-                
+
                 let sectors = device.get_sectors();
                 erase_options.push(EraseOption {
                     device: device.get_device_path().to_path_buf(),

--- a/src/disk/config/disk.rs
+++ b/src/disk/config/disk.rs
@@ -15,7 +15,6 @@ use std::fs::File;
 use std::io::{self, Read};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::ptr;
 use std::str;
 
 /// Detects a partition on the device, if it exists.
@@ -71,8 +70,6 @@ pub struct Disk {
     pub(crate) mklabel: bool,
     /// The partitions that are stored on the device.
     pub(crate) partitions: Vec<PartitionInfo>,
-    /// A pointer back to the parent which owns this disk. Use caution.
-    pub(crate) parent: *const Disks,
 }
 
 impl DiskExt for Disk {
@@ -89,14 +86,6 @@ impl DiskExt for Disk {
     fn get_model(&self) -> &str { &self.model_name }
 
     fn get_mount_point(&self) -> Option<&Path> { self.mount_point.as_ref().map(|x| x.as_path()) }
-
-    fn get_parent<'a>(&'a self) -> Option<&'a Disks> {
-        if self.parent.is_null() {
-            None
-        } else {
-            Some(unsafe { &*self.parent })
-        }
-    }
 
     fn get_partitions_mut(&mut self) -> &mut [PartitionInfo] { &mut self.partitions }
 
@@ -190,7 +179,6 @@ impl Disk {
             } else {
                 Vec::new()
             },
-            parent: ptr::null(),
         })
     }
 

--- a/src/disk/config/disks.rs
+++ b/src/disk/config/disks.rs
@@ -40,8 +40,7 @@ impl Disks {
     }
 
     /// Adds a disk to the disks configuration.
-    pub fn add(&mut self, mut disk: Disk) {
-        disk.parent = &*self as *const Disks;
+    pub fn add(&mut self, disk: Disk) {
         self.physical.push(disk);
     }
 
@@ -347,7 +346,6 @@ impl Disks {
                     device.add_partitions();
                 }
 
-                device.parent = &*self as *const Disks;
                 self.logical.push(device);
                 Ok(())
             }
@@ -865,7 +863,6 @@ impl Disks {
             }
 
             device.add_partitions();
-            device.parent = &*self as *const Disks;
         }
 
         self.logical = existing_devices;

--- a/src/disk/config/lvm/mod.rs
+++ b/src/disk/config/lvm/mod.rs
@@ -10,13 +10,13 @@ use super::super::external::{
 };
 use super::super::mounts::Mounts;
 use super::super::{
-    DiskError, DiskExt, Disks, PartitionError, PartitionInfo, PartitionTable,
+    DiskError, DiskExt, PartitionError, PartitionInfo, PartitionTable,
     PartitionType, FORMAT, REMOVE, SOURCE,
 };
 use super::get_size;
 use rand::{self, Rng};
 use std::ffi::OsStr;
-use std::{io, ptr, thread};
+use std::{io, thread};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -54,7 +54,6 @@ pub struct LvmDevice {
     pub(crate) encryption:   Option<LvmEncryption>,
     pub(crate) is_source:    bool,
     pub(crate) remove:       bool,
-    pub(crate) parent:       *const Disks,
 }
 
 impl DiskExt for LvmDevice {
@@ -77,14 +76,6 @@ impl DiskExt for LvmDevice {
     fn get_model(&self) -> &str { &self.model_name }
 
     fn get_mount_point(&self) -> Option<&Path> { self.mount_point.as_ref().map(|x| x.as_path()) }
-
-    fn get_parent<'a>(&'a self) -> Option<&'a Disks> {
-        if self.parent.is_null() {
-            None
-        } else {
-            Some(unsafe { &*self.parent })
-        }
-    }
 
     fn get_partitions_mut(&mut self) -> &mut [PartitionInfo] { &mut self.partitions }
 
@@ -130,7 +121,6 @@ impl LvmDevice {
             encryption,
             is_source,
             remove: false,
-            parent: ptr::null(),
         }
     }
 

--- a/src/disk/config/mod.rs
+++ b/src/disk/config/mod.rs
@@ -104,7 +104,6 @@ pub(crate) fn get_size(path: &Path) -> io::Result<u64> {
 mod tests {
     use super::*;
     use disk::operations::*;
-    use std::ptr;
 
     fn get_default() -> Disks {
         Disks {
@@ -120,7 +119,6 @@ mod tests {
                 device_type: "TEST".into(),
                 table_type:  Some(PartitionTable::Gpt),
                 read_only:   false,
-                parent:      ptr::null_mut(),
                 partitions:  vec![
                     PartitionInfo {
                         bitflags:     ACTIVE | BUSY | SOURCE,
@@ -211,7 +209,6 @@ mod tests {
                 table_type:  Some(PartitionTable::Gpt),
                 read_only:   false,
                 partitions:  Vec::new(),
-                parent:      ptr::null_mut(),
             }],
             logical:  Vec::new(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,9 +311,10 @@ impl Installer {
 
         callback(20);
 
+        let disks_ptr = &*disks as *const Disks;
         for disk in disks.get_physical_devices_mut() {
             // This will help us when we are testing in a dev environment.
-            if disk.contains_mount("/") {
+            if disk.contains_mount("/", unsafe { &*disks_ptr }) {
                 continue
             }
 


### PR DESCRIPTION
Removes a possible source of instability that could cause a crash.
This could cause a crash when the parent Disks struct is moved due to move semantics.
Requires slight API change to the C FFI.