### PR TITLE
Only attempt to apply recovery changes when the recovery partition exists

### DIFF
--- a/src/disk/config/disks.rs
+++ b/src/disk/config/disks.rs
@@ -357,13 +357,16 @@ impl Disks {
 
     /// Sometimes, physical devices themselves may be mounted directly.
     pub fn unmount_devices(&self) -> Result<(), DiskError> {
+        info!("libdistinst: unmounting devices");
         for device in self.get_physical_devices() {
             if let Some(mount) = device.get_mount_point() {
-                info!(
-                    "libdistinst: unmounting device mounted at {}",
-                    mount.display()
-                );
-                mount::umount(&mount, false).map_err(|why| DiskError::Unmount { why })?;
+                if mount != Path::new("/cdrom") {
+                    info!(
+                        "libdistinst: unmounting device mounted at {}",
+                        mount.display()
+                    );
+                    mount::umount(&mount, false).map_err(|why| DiskError::Unmount { why })?;
+                }
             }
         }
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -88,11 +88,13 @@ else
     update-grub
 fi
 
+RECOVERY_UUID="$(findmnt -n -o UUID /recovery)" || true
+
 # Prepare recovery partition, if it exists
-if [ -d "/boot/efi" -a -d "/cdrom" -a -d "/recovery" ]
+if [ -d "/boot/efi" -a -d "/cdrom" -a -n ${RECOVERY_UUID} ]
 then
     EFI_UUID="$(findmnt -n -o UUID /boot/efi)"
-    RECOVERY_UUID="$(findmnt -n -o UUID /recovery)"
+
     CDROM_UUID="$(findmnt -n -o UUID /cdrom)"
 
     CASPER="casper-${RECOVERY_UUID}"


### PR DESCRIPTION
Fixes the following issue:

1. Do a clean install
2. Do a custom install to reinstall, but do not format `/`, and do not set a mount for `/recovery`

It will fail, because the /recovery directory exists, but has no device mounted to it.