### PR TITLE
Log chroot outputs to installer logs

### DIFF
--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -303,17 +303,17 @@ namespace Distinst {
      * in the library which contains information from `/etc/os-release`.
      */
 
-    public uint8[] get_os_bug_report_url ();
-    public uint8[] get_os_home_url ();
-    public uint8[] get_os_id_like ();
-    public uint8[] get_os_id ();
-    public uint8[] get_os_name ();
-    public uint8[] get_os_pretty_name ();
-    public uint8[] get_os_privacy_policy_url ();
-    public uint8[] get_os_support_url ();
-    public uint8[] get_os_version_codename ();
-    public uint8[] get_os_version_id ();
-    public uint8[] get_os_version ();
+    public unowned uint8[] get_os_bug_report_url ();
+    public unowned uint8[] get_os_home_url ();
+    public unowned uint8[] get_os_id_like ();
+    public unowned uint8[] get_os_id ();
+    public unowned uint8[] get_os_name ();
+    public unowned uint8[] get_os_pretty_name ();
+    public unowned uint8[] get_os_privacy_policy_url ();
+    public unowned uint8[] get_os_support_url ();
+    public unowned uint8[] get_os_version_codename ();
+    public unowned uint8[] get_os_version_id ();
+    public unowned uint8[] get_os_version ();
 
     [CCode (cname = "DISTINST_PARTITION_FLAG", has_type_id = false)]
     public enum PartitionFlag {

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -85,7 +85,7 @@ impl Chroot {
 
                     while let Ok(read) = stderr.read_line(buffer) {
                         if read == 0 { break }
-                        info!("{}", buffer.trim());
+                        warn!("{}", buffer.trim());
                         buffer.clear();
                     }
 


### PR DESCRIPTION
This way, if the installer hangs while on the `configure.sh`, or has an error, that error should be reported in the installer UI's logs. Logs shouldn't be required to be obtained from the terminal.