### PR TITLE
Add function for deactivating all opened encrypted devices

### DIFF
--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -225,6 +225,11 @@ namespace Distinst {
     }
 
     /**
+     * Deactivates all logical devices. Should be executed at the start of the installer.
+     */
+    public int deactivate_logical_devices ();
+
+    /**
      * Hashes the contents of `/dev/`; useful for detecting layout changes.
      */
     public uint64 device_layout_hash ();

--- a/ffi/src/lvm.rs
+++ b/ffi/src/lvm.rs
@@ -1,4 +1,4 @@
-use distinst::{DiskExt, Disks, LvmDevice, PartitionBuilder, PartitionInfo, Sector};
+use distinst::{deactivate_logical_devices, DiskExt, Disks, LvmDevice, PartitionBuilder, PartitionInfo, Sector};
 use ffi::AsMutPtr;
 use libc;
 
@@ -6,6 +6,17 @@ use super::{get_str, null_check, DistinstDisks, DistinstPartition, DistinstParti
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr;
+
+#[no_mangle]
+pub unsafe extern "C" fn distinst_deactivate_logical_devices() -> libc::c_int {
+    match deactivate_logical_devices() {
+        Ok(()) => 0,
+        Err(why) => {
+            error!("unable to deactivate logical devices: {}", why);
+            -1
+        }
+    }
+}
 
 // Initializes the initial volume groups within the disks object.
 #[no_mangle]


### PR DESCRIPTION
- Can enable the front end to start with all encrypted devices closed
- Can also be used to deactivate devices when exiting from a custom partitioning screen
- Fixes a logic error that may delete the PVs & VGs when reinstalling onto an existing PV & VG.