### PR TITLE
Fix keyboard layout issue

### DIFF
--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -49,6 +49,9 @@ impl Chroot {
         cmd: S,
         args: I,
     ) -> Result<ExitStatus> {
+        // Ensure that localectl writes to the chroot, instead.
+        let _etc_mount = Mount::new(&self.path.join("etc"), "/etc", "none", BIND, None)?;
+
         let mut command = Command::new("chroot");
         command.arg(&self.path);
         command.arg(cmd.as_ref());

--- a/src/disk/mount.rs
+++ b/src/disk/mount.rs
@@ -81,13 +81,14 @@ impl Mount {
     /// The `fstype` should contain the file system that will be used, such as `"ext4"`,
     /// or `"vfat"`. If a file system is not valid in the context which the mount is used,
     /// then the value should be `"none"` (as in a binding).
-    pub fn new<P: AsRef<Path>>(
-        src: P,
-        target: &Path,
+    pub fn new<S: AsRef<Path>, T: AsRef<Path>>(
+        src: S,
+        target: T,
         fstype: &str,
         flags: c_ulong,
         options: Option<&str>,
     ) -> Result<Mount> {
+        let target = target.as_ref();
         info!(
             "libdistinst: mounting {} to {}",
             src.as_ref().display(),

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -44,6 +44,8 @@ update-locale --reset "LANG=${LANG}"
 
 # Set keyboard settings system-wide
 localectl set-x11-keymap "${KBD_LAYOUT}" "${KBD_MODEL}" "${KBD_VARIANT}"
+SYSTEMCTL_SKIP_REDIRECT=_ openvt -- sh /etc/init.d/console-setup.sh reload
+ln -s /etc/console-setup/cached_UTF-8_del.kmap.gz /etc/console-setup/cached.kmap.gz
 
 # Remove installer packages
 apt-get purge -y "${PURGE_PKGS[@]}"


### PR DESCRIPTION
The keyboard layout selected in the UI should now apply to cryptsetup. This new solution is much cleaner than the last workaround attempt.

### localectl fix

systemd's localectl command will always apply changes where the systemd service is running. Which means that running systemd commands within a chroot will apply those changes to the owner of the chroot. Thus, the configuration changes are going to the live environment's `/etc` directory, rather than the install chroot's.

- bind mount the chroot's `/etc` to the host's `/etc` before running the chroot command
- unmount that binding after the command is complete, so that the binding will never exist for longer than chroot is entered.

### console-setup fix

Console setup also requires a quick fix so that the initial system state uses the specified key map.

- Ensure that console-setup is reloaded with `SYSTEMCTL_SKIP_REDIRECT=_ openvt -- sh /etc/init.d/console-setup.sh reload`
- Symbolically link the preferred key map so that the initramfs will use it, with `ln -s /etc/console-setup/cached_UTF-8_del.kmap.gz /etc/console-setup/cached.kmap.gz`

@brs17 This should finally fix the problem. Might be good to have this in before the next ISO is made.