### PR TITLE
Cut CPU usage by 200% while idling

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -65,6 +65,7 @@ pub fn get_checksum<P: AsRef<Path>>(path: P, buffer: &mut [u8; 8124]) -> io::Res
     let mut hasher = DefaultHasher::new();
 
     while let Ok(read) = file.read(buffer) {
+        if read == 0 { break }
         hasher.write(&buffer[..read]);
     }
 


### PR DESCRIPTION
Noticed within the installer that the CPU usage was consistently over 200% (two full cores), due to an endless loop of reads. This will fix that.