### PR TITLE
Encrypted Ubuntu Installations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "distinst"
 version = "0.4.0"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cascade 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,6 +1001,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "899ec79626c14e00ccc9729b4d750bbe67fe76a8f436824c16e0233bbd9d7daa"
+"checksum dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f679c09c1cf5428702cc10f6846c56e4e23420d3a88bcc9335b17c630a7b710b"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde-xml-rs = "0.2.1"
 tempdir = "0.3.7"
 bitflags = "1.0.3"
 cascade = "0.1.2"
+dirs = "1.0.3"
 
 [dependencies.failure]
 version = "0.1.2"

--- a/examples/default_install.rs
+++ b/examples/default_install.rs
@@ -99,7 +99,7 @@ fn main() {
             let disk = args.next().unwrap();
             let disk = Path::new(&disk);
 
-            match options.erase_options.iter().find(|opt| &opt.device == disk) {
+            match options.erase_options.iter().find(|opt| opt.device == disk) {
                 Some(option) => {
                     let option = InstallOption::Erase {
                         option,

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -142,8 +142,8 @@ fn alongside_config(
         let mut create_esp = false;
 
         {
-            let partitions = device.partitions.iter_mut();
-            match partitions.filter(|p| p.is_esp_partition() && p.sectors() > 819_200).next() {
+            let mut partitions = device.partitions.iter_mut();
+            match partitions.find(|p| p.is_esp_partition() && p.sectors() > 819_200) {
                 Some(esp) => esp.set_mount("/boot/efi".into()),
                 None => create_esp = true
             }

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -178,7 +178,7 @@ impl InstallOptions {
         }
 
         let mut alongside_options = Vec::new();
-        for (device, data) in other_os.into_iter() {
+        for (device, data) in other_os {
             if data.systems.len() == 1 {
                 if required_space < data.sectors_free {
                     alongside_options.push(AlongsideOption {

--- a/src/disk/config/disk.rs
+++ b/src/disk/config/disk.rs
@@ -833,7 +833,7 @@ impl Disk {
                     ops.remove()
                         .and_then(|ops| ops.change())
                         .and_then(|ops| ops.create())
-                        .map(|format| Some(format))
+                        .map(Some)
                 }
             })
         })

--- a/src/disk/config/partitions/usage.rs
+++ b/src/disk/config/partitions/usage.rs
@@ -480,7 +480,7 @@ Please make a test run using both the -n and -s options before real resizing!"#;
     #[test]
     fn ntfs_usage() {
         let reader = NTFS_INPUT.lines().map(|x| Ok(x.into()));
-        assert_eq!(get_ntfs_usage(reader, 512).unwrap(), 133256);
+        assert_eq!(get_ntfs_usage(reader, 512).unwrap(), 133_256);
     }
 
     const BTRFS_INPUT: &str = r#"Label: none  uuid: 8a69ba4c-6cf5-46cc-aff3-f0c23251a21b

--- a/src/disk/mounts.rs
+++ b/src/disk/mounts.rs
@@ -109,7 +109,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use super::*;
 
-    const SAMPLE: &'static str = r#"sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+    const SAMPLE: &str = r#"sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
 proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
 udev /dev devtmpfs rw,nosuid,relatime,size=16420480k,nr_inodes=4105120,mode=755 0 0
 tmpfs /run tmpfs rw,nosuid,noexec,relatime,size=3291052k,mode=755 0 0

--- a/src/disk/serial.rs
+++ b/src/disk/serial.rs
@@ -35,7 +35,7 @@ fn parse_serial(data: &[u8]) -> io::Result<String> {
 mod tests {
     use super::*;
 
-    const SAMPLE: &'static str = r#"P: /devices/pci0000:00/0000:00:17.0/ata4/host3/target3:0:0/3:0:0:0/block/sda
+    const SAMPLE: &str = r#"P: /devices/pci0000:00/0000:00:17.0/ata4/host3/target3:0:0/3:0:0:0/block/sda
 N: sda
 S: disk/by-id/ata-Samsung_SSD_850_EVO_500GB_S21HNXAG806916N
 S: disk/by-id/wwn-0x5002538d403d649a

--- a/src/disk/swaps.rs
+++ b/src/disk/swaps.rs
@@ -103,7 +103,7 @@ mod tests {
     use std::path::PathBuf;
     use std::ffi::OsString;
 
-    const SAMPLE: &'static str = r#"Filename				Type		Size	Used	Priority
+    const SAMPLE: &str = r#"Filename				Type		Size	Used	Priority
 /dev/sda5                               partition	8388600	0	-2"#;
 
     #[test]

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -96,6 +96,7 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
     }
 }
 
+
 pub fn get_required_packages(flags: FileSystemSupport) -> Vec<&'static str> {
     let mut retain = Vec::new();
 
@@ -128,7 +129,7 @@ pub fn get_required_packages(flags: FileSystemSupport) -> Vec<&'static str> {
     }
 
     if flags.intersects(FileSystemSupport::LVM | FileSystemSupport::LUKS) {
-        retain.extend_from_slice(&["lvm2", "dmeventd", "dmraid"]);
+        retain.extend_from_slice(&["lvm2", "dmeventd", "dmraid", "kpartx", "kpartx-boot"]);
     }
 
     retain

--- a/src/hardware_support/modules.rs
+++ b/src/hardware_support/modules.rs
@@ -40,7 +40,7 @@ impl Module {
 mod tests {
     use super::*;
 
-    const SAMPLE: &'static str = r#"snd_hda_intel 40960 9 - Live 0x0000000000000000
+    const SAMPLE: &str = r#"snd_hda_intel 40960 9 - Live 0x0000000000000000
 snd_hda_codec 126976 4 snd_hda_codec_hdmi,snd_hda_codec_realtek,snd_hda_codec_generic,snd_hda_intel, Live 0x0000000000000000
 snd_hda_core 81920 5 snd_hda_codec_hdmi,snd_hda_codec_realtek,snd_hda_codec_generic,snd_hda_intel,snd_hda_codec, Live 0x0000000000000000
 nvidia_drm 40960 11 - Live 0x0000000000000000 (POE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,6 +1088,7 @@ impl Installer {
         Ok(())
     }
 
+    // TODO: Rewrite this as a state machine without needing the macros.
     /// The user will use this method to hand off installation tasks to distinst.
     ///
     /// The `disks` field contains all of the disks configuration information that will be

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -150,7 +150,7 @@ EOF
 fi
 
 # This is allowed to fail
-if [ $DISABLE_NVIDIA ]; then
+if [ $DISABLE_NVIDIA -eq "1" ]; then
     systemctl disable nvidia-fallback.service || true
 fi
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,54 @@
+use libc;
+use std::io;
+use std::sync::atomic::Ordering;
+use super::{Installer, Status, Error, Step, KILL_SWITCH};
+
+pub struct InstallerState<'a> {
+    pub installer: &'a mut Installer,
+    pub status: Status,
+}
+
+impl<'a> InstallerState<'a> {
+    pub fn new(installer: &'a mut Installer) -> Self {
+        Self { installer, status: Status { step: Step::Init, percent: 0 }}
+    }
+
+    pub fn apply<T, F>(&mut self, step: Step, msg: &str, mut action: F) -> io::Result<T>
+        where F: for<'b> FnMut(&'b mut Self) -> io::Result<T>
+    {
+        unsafe {
+            libc::sync();
+        }
+
+        if KILL_SWITCH.load(Ordering::SeqCst) {
+            return Err(io::Error::new(io::ErrorKind::Interrupted, "process killed"));
+        }
+
+        self.status.step = step;
+        self.status.percent = 0;
+        let status = self.status;
+        self.emit_status(status);
+
+        info!("starting {} step", msg);
+        match action(self) {
+            Ok(value) => Ok(value),
+            Err(err) => {
+                error!("{} error: {}", msg, err);
+                let error = Error {
+                    step: self.status.step,
+                    err,
+                };
+                self.emit_error(&error);
+                Err(error.err)
+            }
+        }
+    }
+
+    pub fn emit_status(&mut self, status: Status) {
+        self.installer.emit_status(status);
+    }
+
+    pub fn emit_error(&mut self, error: &Error) {
+        self.installer.emit_error(&error);
+    }
+}


### PR DESCRIPTION
Made some changes to remove a complex macro from the `Installer::install()` function. Encrypted installations with `grub-efi` are now possible, as well.

- [x] Performed an encrypted install of Ubuntu with an unencrypted `/boot` partition.
- [x] Performed an encrypted install of Ubuntu without it.
- [x] Performed Pop!_OS install to ensure that continues to work.