### PR TITLE
Support interaction with the dbus systemd login1 manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +217,7 @@ version = "0.4.0"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cascade 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbus 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -378,6 +388,14 @@ version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libloading"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +530,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -1000,6 +1023,7 @@ dependencies = [
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
+"checksum dbus 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e34c238dfb3f5881d46ad301403cd8f8ecf946e2a4e89bdd1166728b68b5008"
 "checksum derive-new 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "899ec79626c14e00ccc9729b4d750bbe67fe76a8f436824c16e0233bbd9d7daa"
 "checksum dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f679c09c1cf5428702cc10f6846c56e4e23420d3a88bcc9335b17c630a7b710b"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
@@ -1020,6 +1044,7 @@ dependencies = [
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum libdbus-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8720f9274907052cb50313f91201597868da9d625f8dd125f2aca5bddb7e83a1"
 "checksum libloading 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fd38073de8f7965d0c17d30546d4bb6da311ab428d1c7a3fc71dff7f9d4979b9"
 "checksum libparted 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a46101492e623f2d20b057d101408d26ec9bbd83cf83b8de6fb523d143164703"
 "checksum libparted-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16498f117aee52a1caa4523a6ecd9806ba81e176f0f2b489bd308e77eb83524a"
@@ -1037,6 +1062,7 @@ dependencies = [
 "checksum phf_codegen 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4048fe7dd7a06b8127ecd6d3803149126e9b33c7558879846da3a63f734f2b"
 "checksum phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "05a079dd052e7b674d21cb31cbb6c05efd56a2cd2827db7692e2f1a507ebd998"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
 "checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
 "checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tempdir = "0.3.7"
 bitflags = "1.0.3"
 cascade = "0.1.2"
 dirs = "1.0.3"
+dbus = "0.6.2"
 
 [dependencies.failure]
 version = "0.1.2"

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends:
   cargo,
   clang,
   gettext,
+  libdbus-1-dev,
   libparted-dev
 Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/distinst

--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -311,6 +311,13 @@ namespace Distinst {
     public bool validate_hostname (string hostname);
 
     /**
+     * Inhibits suspend via org.freedesktop.login1.Manager.
+     *
+     * Returns a raw file descriptor which will unlock the inhibitor when closed.
+     */
+    public int session_inhibit_suspend ();
+
+    /**
      * The followting functions take information from a static structure
      * in the library which contains information from `/etc/os-release`.
      */

--- a/ffi/src/dbus.rs
+++ b/ffi/src/dbus.rs
@@ -1,0 +1,21 @@
+use distinst::dbus_interfaces::LoginManager;
+use libc;
+
+#[no_mangle]
+pub extern "C" fn distinst_session_inhibit_suspend() -> libc::c_int {
+    let manager = match LoginManager::new() {
+        Ok(manager) => manager,
+        Err(why) => {
+            error!("failed to get logind manager: {}", why);
+            return -1;
+        }
+    };
+
+    match manager.connect().inhibit_suspend() {
+        Ok(pipe_fd) => pipe_fd.into_fd(),
+        Err(why) => {
+            error!("failed to suspend: {}", why);
+            return -1;
+        }
+    }
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -11,6 +11,7 @@ use std::ptr;
 
 pub use self::auto::*;
 pub use self::config::*;
+pub use self::dbus::*;
 pub use self::disk::*;
 pub use self::filesystem::*;
 pub use self::installer::*;
@@ -28,6 +29,7 @@ use std::io;
 
 mod auto;
 mod config;
+mod dbus;
 mod disk;
 mod ffi;
 mod filesystem;

--- a/src/dbus_interfaces/logind.rs
+++ b/src/dbus_interfaces/logind.rs
@@ -1,0 +1,49 @@
+use dbus::{self, arg, BusType, Connection, ConnPath};
+use std::ops::Deref;
+
+pub struct LoginManager {
+    conn: Connection
+}
+
+impl Deref for LoginManager {
+    type Target = Connection;
+    fn deref(&self) -> &Self::Target {
+        &self.conn
+    }
+}
+
+impl LoginManager {
+    pub fn new() -> Result<LoginManager, dbus::Error> {
+        Ok(Self { conn: Connection::get_private(BusType::System)? })
+    }
+
+    pub fn connect(&self) -> LoginManagerConnection {
+        LoginManagerConnection {
+            conn: self.with_path("org.freedesktop.login1", "/org/freedesktop/login1", 1000)
+        }
+    }
+}
+
+pub struct LoginManagerConnection<'a> {
+    conn: ConnPath<'a, &'a Connection>
+}
+
+impl<'a> LoginManagerConnection<'a> {
+    pub fn inhibit_suspend(&self) -> Result<dbus::OwnedFd, dbus::Error> {
+        let mut m = self.conn.method_call_with_args(
+            &"org.freedesktop.login1.Manager".into(),
+            &"Inhibit".into(),
+            |msg| {
+                cascade! {
+                    arg::IterAppend::new(msg);
+                    ..append("idle:shutdown:sleep");
+                    ..append("Distinst Installer");
+                    ..append("Installing Linux distribution");
+                    ..append("block");
+                }
+            })?;
+
+        m.as_result()?;
+        Ok(m.iter_init().read::<dbus::OwnedFd>()?)
+    }
+}

--- a/src/dbus_interfaces/mod.rs
+++ b/src/dbus_interfaces/mod.rs
@@ -1,0 +1,3 @@
+mod logind;
+
+pub use self::logind::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate bitflags;
 #[macro_use]
 extern crate cascade;
 extern crate dirs;
+extern crate dbus;
 #[macro_use]
 extern crate derive_new;
 extern crate failure;
@@ -62,6 +63,7 @@ pub use misc::device_layout_hash;
 pub mod auto;
 mod chroot;
 mod disk;
+pub mod dbus_interfaces;
 mod distribution;
 mod envfile;
 mod hardware_support;


### PR DESCRIPTION
UIs will no longer need to write their own code to inhibit suspension on systemd systems.

Vala example:

```vala
int pipe_fd = Distinst.session_inhibit_suspend ();
if (pipe_fd == -1) {
    stderr.printf ("failed to inhibit suspension\n");
}

// Any attempt to suspend after this point will fail
// and/or request the user to unlock the inhibitor.

do_things ();

// At a later point, when the caller wants to unlock the inhibitor:
Posix.close (pipe_fd);
```