### PR TITLE
EFI GPT Checks

### DIFF
--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -664,6 +664,11 @@ namespace Distinst {
         public uint64 get_sector (ref Sector sector);
 
         /**
+         * Identifies the type of table that the disk has.
+         */
+        public PartitionTable get_partition_table ();
+
+        /**
          * Returns true if the device contains a partition mounted at the specified target.
          */
         public bool contains_mount (string mount, Distinst.Disks disks);
@@ -884,7 +889,7 @@ namespace Distinst {
          * that is associated with the given target mount point. Scans both physical
          * and logical partitions.
          */
-        public PartitionAndDiskPath find_partition (string target);
+        public PartitionAndDiskPath? find_partition (string target);
 
         /**
          * True if any partition on the disk is a LUKS partition.

--- a/ffi/src/disk.rs
+++ b/ffi/src/disk.rs
@@ -244,6 +244,18 @@ pub unsafe extern "C" fn distinst_disk_get_sector(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn distinst_disk_get_partition_table(
+    disk: *const DistinstDisk
+) -> DISTINST_PARTITION_TABLE {
+    if null_check(disk).is_err() {
+        return DISTINST_PARTITION_TABLE::NONE;
+    }
+
+    let disk = &*(disk as *const Disk);
+    disk.get_table_type().into()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn distinst_disk_mklabel(
     disk: *mut DistinstDisk,
     table: DISTINST_PARTITION_TABLE,

--- a/ffi/src/partition.rs
+++ b/ffi/src/partition.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::ptr;
 
 use distinst::{
-    Bootloader, FileSystemType, LvmEncryption, PartitionBuilder, PartitionFlag, PartitionInfo, PartitionType,
+    Bootloader, FileSystemType, LvmEncryption, PartitionTable, PartitionBuilder, PartitionFlag, PartitionInfo, PartitionType,
 };
 use filesystem::DISTINST_FILE_SYSTEM_TYPE;
 use {gen_object_ptr, null_check, get_str, DistinstLvmEncryption};
@@ -17,6 +17,16 @@ pub enum DISTINST_PARTITION_TABLE {
     NONE = 0,
     GPT = 1,
     MSDOS = 2,
+}
+
+impl From<Option<PartitionTable>> for DISTINST_PARTITION_TABLE {
+    fn from(table: Option<PartitionTable>) -> Self {
+        match table {
+            Some(PartitionTable::Msdos) => DISTINST_PARTITION_TABLE::MSDOS,
+            Some(PartitionTable::Gpt) => DISTINST_PARTITION_TABLE::GPT,
+            None => DISTINST_PARTITION_TABLE::NONE
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/disk/config/disk_trait.rs
+++ b/src/disk/config/disk_trait.rs
@@ -76,6 +76,8 @@ pub trait DiskExt {
             .map_or_else(check_partitions, |m| m == Path::new(mount))
     }
 
+    fn is_logical(&self) -> bool { Self::LOGICAL }
+
     /// Checks if the drive is a removable drive.
     fn is_removable(&self) -> bool {
         let path = {


### PR DESCRIPTION
- Allows the caller to get the partition table of a disk to determine if an EFI partition on that disk is a valid configuration.
- Additionally checks itself before installing to see if the provided input is correct.