### PR TITLE
installer/steps/configure: sync before unmounting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -902,6 +902,7 @@ impl Installer {
             drop(efivars_mount);
 
             cdrom_target.map(|target| fs::remove_dir(&target));
+            unsafe { libc::sync(); }
             chroot.unmount(false)?;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1070,6 +1070,7 @@ impl Installer {
                 }
 
                 drop(efivars_mount);
+                unsafe { libc::sync(); }
                 chroot.unmount(false)?;
             }
         }


### PR DESCRIPTION
Invoke `sync()` before unmounting the chroot in the configure step.