### PR TITLE
Fix encrypted installs on 18.10

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -107,7 +107,7 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
 }
 
 
-pub fn get_required_packages(disks: &Disks, _release: &OsRelease) -> Vec<&'static str> {
+pub fn get_required_packages(disks: &Disks, release: &OsRelease) -> Vec<&'static str> {
     let flags = disks.get_support_flags();
 
     let mut retain = Vec::new();
@@ -138,6 +138,10 @@ pub fn get_required_packages(disks: &Disks, _release: &OsRelease) -> Vec<&'stati
 
     if flags.contains(FileSystemSupport::LUKS) {
         retain.extend_from_slice(&["cryptsetup", "cryptsetup-bin"]);
+        match (release.id.as_str(), release.version.as_str()) {
+            ("ubuntu", "18.10") => retain.extend_from_slice(&["cryptsetup-initramfs", "cryptsetup-run"]),
+            _ => ()
+        }
     }
 
     if flags.intersects(FileSystemSupport::LVM | FileSystemSupport::LUKS) {

--- a/src/installer/steps/configure.rs
+++ b/src/installer/steps/configure.rs
@@ -210,6 +210,10 @@ pub fn configure<P: AsRef<Path>, S: AsRef<str>, F: FnMut(i32)>(
             None => &[]
         };
 
+        // Add the retained packages to the list of packages to be installed.
+        // There are some packages that Ubuntu will still remove even if they've been removed from the removal list.
+        install_pkgs.extend_from_slice(&retain);
+
         // Filter the discovered language packs and retained packages from the remove list.
         let remove = remove_pkgs.into_iter()
             .map(AsRef::as_ref)
@@ -217,10 +221,6 @@ pub fn configure<P: AsRef<Path>, S: AsRef<str>, F: FnMut(i32)>(
             .collect::<Vec<&str>>();
 
         callback(35);
-
-        // Add the retained packages to the list of packages to be installed.
-        // There are some packages that Ubuntu will still remove even if they've been removed from the removal list.
-        install_pkgs.extend_from_slice(&retain);
 
         // TODO: use a macro to make this more manageable.
         let chroot = ChrootConfigurator::new(chroot);


### PR DESCRIPTION
- The new manifest-remove includes `cryptsetup-{initramfs,run}` now.
- Added an additional check to `debian::get_required_packages()` to retain them.

Closes #150