### PR TITLE
Use PartUUID for mounting FAT partitions instead of UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "partition-identity"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/partition-identity#139a3e137a674cc1158746cf4a015bcc30f6e06b"
+source = "git+https://github.com/pop-os/partition-identity#1702e86166c4552429bfe8ae2f5a080f222c1c11"
 
 [[package]]
 name = "pbr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "libparted 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "partition-identity 0.1.0 (git+https://github.com/pop-os/partition-identity)",
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,6 +514,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "partition-identity"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/partition-identity#139a3e137a674cc1158746cf4a015bcc30f6e06b"
 
 [[package]]
 name = "pbr"
@@ -1104,6 +1110,7 @@ dependencies = [
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum partition-identity 0.1.0 (git+https://github.com/pop-os/partition-identity)" = "<none>"
 "checksum pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "deb73390ab68d81992bd994d145f697451bb0b54fd39738e72eef32458ad6907"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum phf 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7d37a244c75a9748e049225155f56dbcb98fe71b192fd25fd23cb914b5ad62f2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ cascade = "0.1.2"
 dirs = "1.0.3"
 dbus = "0.6.2"
 sys-mount = "1.0.3"
+partition-identity = { git = "https://github.com/pop-os/partition-identity" }
 
 [dependencies.failure]
 version = "0.1.2"

--- a/ffi/src/auto.rs
+++ b/ffi/src/auto.rs
@@ -1,13 +1,10 @@
 use libc;
 
-use super::{gen_object_ptr, get_str, null_check, DistinstDisks, DISTINST_FILE_SYSTEM_TYPE};
-use distinst::FileSystemType;
-use distinst::auto::{delete_old_install, AlongsideMethod, AlongsideOption, EraseOption, InstallOption,
+use super::{gen_object_ptr, get_str, null_check, DistinstDisks};
+use distinst::auto::{AlongsideMethod, AlongsideOption, EraseOption, InstallOption,
     InstallOptions, RecoveryOption, RefreshOption};
 use distinst::Disks;
-use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
 use std::ptr;
 
 #[repr(C)]

--- a/ffi/src/disk.rs
+++ b/ffi/src/disk.rs
@@ -497,8 +497,7 @@ pub unsafe extern "C" fn distinst_disks_get_partition_by_uuid(
     match get_str(uuid) {
         Ok(uuid) => {
             let disks = &mut *(disks as *mut Disks);
-            eprintln!("finding '{}'", uuid);
-            disks.get_partition_by_uuid_mut(uuid).as_mut_ptr() as *mut DistinstPartition
+            disks.get_partition_by_uuid_mut(uuid.to_owned()).as_mut_ptr() as *mut DistinstPartition
         }
         Err(why) => {
             eprintln!("libdistinst: uuid is not UTF-8: {}", why);

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -12,12 +12,11 @@ pub use self::erase_option::*;
 pub use self::recovery_option::*;
 pub use self::refresh_option::*;
 
-use std::path::PathBuf;
-
-use super::super::*;
-use misc::get_uuid;
-use std::collections::HashMap;
+use partition_identity::PartitionID;
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use super::super::*;
 
 #[derive(Debug)]
 pub struct InstallOptions {
@@ -52,8 +51,8 @@ impl InstallOptions {
                                 os_name:        info.name.clone(),
                                 os_pretty_name: info.pretty_name.clone(),
                                 os_version:     info.version.clone(),
-                                root_part:      get_uuid(part.get_device_path())
-                                    .expect("root device did not have uuid"),
+                                root_part:      PartitionID::get_uuid(part.get_device_path())
+                                    .expect("root device did not have uuid").id,
                                 home_part:      home.clone(),
                                 efi_part:       efi.clone(),
                                 recovery_part:  recovery.clone(),

--- a/src/auto/options/recovery_option.rs
+++ b/src/auto/options/recovery_option.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
 use envfile::EnvFile;
+use partition_identity::PartitionID;
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct RecoveryOption {
@@ -13,6 +14,24 @@ pub struct RecoveryOption {
     pub recovery_uuid: String,
     pub root_uuid:     String,
     pub luks_uuid:     Option<String>,
+}
+
+impl RecoveryOption {
+    pub fn parse_efi_id(&self) -> Option<PartitionID> {
+        self.efi_uuid.as_ref().map(|uuid| Self::parse_id(uuid.clone()))
+    }
+
+    pub fn parse_recovery_id(&self) -> PartitionID {
+        Self::parse_id(self.recovery_uuid.clone())
+    }
+
+    fn parse_id(id: String) -> PartitionID {
+        if id.starts_with("PARTUUID=") {
+            PartitionID::new_partuuid(id[9..].to_owned())
+        } else {
+            PartitionID::new_uuid(id)
+        }
+    } 
 }
 
 const RECOVERY_CONF: &str = "/cdrom/recovery.conf";

--- a/src/auto/options/refresh_option.rs
+++ b/src/auto/options/refresh_option.rs
@@ -1,5 +1,5 @@
+use partition_identity::PartitionID;
 use std::fmt;
-use misc::from_uuid;
 
 #[derive(Debug)]
 pub struct RefreshOption {
@@ -15,7 +15,7 @@ pub struct RefreshOption {
 
 impl fmt::Display for RefreshOption {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let root_part: String = match from_uuid(&self.root_part) {
+        let root_part: String = match PartitionID::new_uuid(self.root_part.clone()).get_device_path() {
             Some(uuid) => uuid.to_string_lossy().into(),
             None => "None".into(),
         };

--- a/src/disk/config/partitions/block_info.rs
+++ b/src/disk/config/partitions/block_info.rs
@@ -1,7 +1,6 @@
 
-use partition_identity::{PartitionID, PartitionIDVariant};
+use partition_identity::{PartitionID, PartitionSource};
 use std::ffi::{OsStr, OsString};
-use std::io;
 use std::path::{Path, PathBuf};
 use super::FileSystemType;
 
@@ -19,16 +18,12 @@ pub(crate) struct BlockInfo {
 
 impl BlockInfo {
     pub fn new(
-        path: &Path,
+        uid: PartitionID,
         fs: FileSystemType,
         target: Option<&Path>
-    ) -> Option<Self> {
-        Some(BlockInfo {
-            uid: if fs == FileSystemType::Fat16 || fs == FileSystemType::Fat32 {
-                PartitionID::by_id(PartitionIDVariant::PartUUID, path)?
-            } else {
-                PartitionID::by_id(PartitionIDVariant::UUID, path)?
-            },
+    ) -> Self {
+        BlockInfo {
+            uid,
             mount: if fs == FileSystemType::Swap {
                 None
             } else {
@@ -42,7 +37,7 @@ impl BlockInfo {
             options: fs.get_preferred_options().into(),
             dump: false,
             pass: false,
-        })
+        }
     }
 
     pub fn mount(&self) -> &OsStr {
@@ -53,14 +48,19 @@ impl BlockInfo {
 
     /// The size of the data contained within.
     pub fn len(&self) -> usize {
-        self.uuid.len() + self.mount().len() + self.fs.len() + self.options.len() + 2
+        self.uid.id.len() + self.mount().len() + self.fs.len() + self.options.len() + 2
     }
 
     pub fn write_fstab(&self, fstab: &mut OsString) {
-        match 
-        fstab.reserve_exact(self.len() + 16);
-        fstab.push("UUID=");
-        fstab.push(&self.uuid);
+        let mount_variant = match self.uid.variant {
+            PartitionSource::UUID => "UUID=",
+            PartitionSource::PartUUID => "PARTUUID=",
+            _ => unimplemented!()
+        };
+
+        fstab.reserve_exact(self.len() + 11 + mount_variant.len());
+        fstab.push(mount_variant);
+        fstab.push(&self.uid.id);
         fstab.push("  ");
         fstab.push(self.mount());
         fstab.push("  ");
@@ -73,6 +73,14 @@ impl BlockInfo {
         fstab.push(if self.pass { "1" } else { "0" });
         fstab.push("\n");
     }
+
+    pub fn get_partition_id(path: &Path, fs: FileSystemType) -> Option<PartitionID> {
+        if fs == FileSystemType::Fat16 || fs == FileSystemType::Fat32 {
+            PartitionID::get_partuuid(path)
+        } else {
+            PartitionID::get_uuid(path)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -82,9 +90,12 @@ mod tests {
 
     #[test]
     fn fstab_entries() {
-        let swap = BlockInfo::new("SWAP".into(), FileSystemType::Swap, None);
-        let efi = BlockInfo::new("EFI".into(), FileSystemType::Fat32, Some(Path::new("/boot/efi")));
-        let root = BlockInfo::new("ROOT".into(), FileSystemType::Ext4, Some(Path::new("/")));
+        let swap_id = PartitionID { id: "SWAP".into(), variant: PartitionSource::UUID };
+        let swap = BlockInfo::new(swap_id, FileSystemType::Swap, None);
+        let efi_id = PartitionID { id: "EFI".into(), variant: PartitionSource::PartUUID };
+        let efi = BlockInfo::new(efi_id, FileSystemType::Fat32, Some(Path::new("/boot/efi")));
+        let root_id = PartitionID { id: "ROOT".into(), variant: PartitionSource::UUID };
+        let root = BlockInfo::new(root_id, FileSystemType::Ext4, Some(Path::new("/")));
 
         let fstab = &mut OsString::new();
         swap.write_fstab(fstab);
@@ -94,7 +105,7 @@ mod tests {
         assert_eq!(
             *fstab,
             OsString::from(r#"UUID=SWAP  none  swap  sw  0  0
-UUID=EFI  /boot/efi  vfat  umask=0077  0  0
+PARTUUID=EFI  /boot/efi  vfat  umask=0077  0  0
 UUID=ROOT  /  ext4  noatime,errors=remount-ro  0  0
 "#)
         );
@@ -102,11 +113,18 @@ UUID=ROOT  /  ext4  noatime,errors=remount-ro  0  0
 
     #[test]
     fn block_info_swap() {
-        let swap = BlockInfo::new("TEST".into(), FileSystemType::Swap, None);
+        let id = PartitionID {
+            variant: PartitionSource::UUID,
+            id: "TEST".to_owned()
+        };
+        let swap = BlockInfo::new(id, FileSystemType::Swap, None);
         assert_eq!(
             swap,
             BlockInfo {
-                uuid: "TEST".into(),
+                uid: PartitionID {
+                    variant: PartitionSource::UUID,
+                    id: "TEST".to_owned()
+                },
                 mount: None,
                 fs: "swap",
                 options: FileSystemType::Swap.get_preferred_options().into(),
@@ -120,11 +138,18 @@ UUID=ROOT  /  ext4  noatime,errors=remount-ro  0  0
 
     #[test]
     fn block_info_efi() {
-        let efi = BlockInfo::new("TEST".into(), FileSystemType::Fat32, Some(Path::new("/boot/efi")));
+        let id = PartitionID {
+            variant: PartitionSource::PartUUID,
+            id: "TEST".to_owned()
+        };
+        let efi = BlockInfo::new(id, FileSystemType::Fat32, Some(Path::new("/boot/efi")));
         assert_eq!(
             efi,
             BlockInfo {
-                uuid: "TEST".into(),
+                uid: PartitionID {
+                    variant: PartitionSource::PartUUID,
+                    id: "TEST".to_owned()
+                },
                 mount: Some(PathBuf::from("/boot/efi")),
                 fs: "vfat",
                 options: FileSystemType::Fat32.get_preferred_options().into(),
@@ -138,11 +163,18 @@ UUID=ROOT  /  ext4  noatime,errors=remount-ro  0  0
 
     #[test]
     fn block_info_root() {
-        let root = BlockInfo::new("TEST".into(), FileSystemType::Ext4, Some(Path::new("/")));
+        let id = PartitionID {
+            variant: PartitionSource::UUID,
+            id: "TEST".to_owned()
+        };
+        let root = BlockInfo::new(id, FileSystemType::Ext4, Some(Path::new("/")));
         assert_eq!(
             root,
             BlockInfo {
-                uuid: "TEST".into(),
+                uid: PartitionID {
+                    variant: PartitionSource::UUID,
+                    id: "TEST".to_owned()
+                },
                 mount: Some(PathBuf::from("/")),
                 fs: FileSystemType::Ext4.into(),
                 options: FileSystemType::Ext4.get_preferred_options().into(),

--- a/src/disk/config/partitions/mod.rs
+++ b/src/disk/config/partitions/mod.rs
@@ -383,20 +383,12 @@ impl PartitionInfo {
             return None;
         }
 
-        let result = BlockInfo::new(
-            &self.device_path,
-            self.filesystem.expect("unable to get block info due to lack of file system"),
+        let fs = self.filesystem.expect("unable to get block info due to lack of file system");
+        Some(BlockInfo::new(
+            BlockInfo::get_partition_id(&self.device_path, fs)?,
+            fs,
             self.target.as_ref().map(|p| p.as_path())
-        );
-
-        if result.is_none() {
-            error!(
-                "{}: no UUID associated with device",
-                self.device_path.display()
-            );
-        }
-
-        result
+        ))
     }
 }
 

--- a/src/disk/config/partitions/mod.rs
+++ b/src/disk/config/partitions/mod.rs
@@ -9,7 +9,6 @@ pub use self::limitations::check_partition_size;
 pub use self::os_detect::OS;
 use FileSystemType::*;
 use libparted::{Partition, PartitionFlag};
-use misc::get_uuid;
 use mnt::{swapoff, MountList, Swaps};
 use process::external::{get_label, is_encrypted};
 use self::block_info::BlockInfo;
@@ -384,12 +383,11 @@ impl PartitionInfo {
             return None;
         }
 
-        let result = get_uuid(&self.device_path).map(|uuid| {
-            let fs = self.filesystem
-                .expect("unable to get block info due to lack of file system");
-
-            BlockInfo::new(uuid, fs, self.target.as_ref().map(|p| p.as_path()))
-        });
+        let result = BlockInfo::new(
+            &self.device_path,
+            self.filesystem.expect("unable to get block info due to lack of file system"),
+            self.target.as_ref().map(|p| p.as_path())
+        );
 
         if result.is_none() {
             error!(

--- a/src/disk/config/partitions/os_detect.rs
+++ b/src/disk/config/partitions/os_detect.rs
@@ -3,7 +3,8 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use tempdir::TempDir;
 use os_release::OsRelease;
-use misc::{self, get_uuid};
+use misc;
+use partition_identity::PartitionID;
 use sys_mount::*;
 
 /// Adds a new map method for boolean types.
@@ -62,7 +63,8 @@ pub fn detect_os(device: &Path, fs: FileSystemType) -> Option<OS> {
 fn find_linux_parts(base: &Path) -> (Option<String>, Option<String>, Option<String>) {
     let parse_fstab_mount = move |mount: &str| -> Option<String> {
         if mount.starts_with('/') {
-            get_uuid(Path::new(mount))
+            PartitionID::get_uuid(mount.to_owned())
+                .map(|id| id.id)
         } else if mount.starts_with("UUID") {
             let (_, uuid) = mount.split_at(5);
             Some(uuid.into())

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -106,7 +106,6 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
     }
 }
 
-
 pub fn get_required_packages(disks: &Disks, release: &OsRelease) -> Vec<&'static str> {
     let flags = disks.get_support_flags();
 

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -201,7 +201,7 @@ impl Installer {
             info!("installing while retaining home");
 
             let old_root = disks
-                .get_partition_by_uuid(old_root_uuid)
+                .get_partition_by_uuid(old_root_uuid.clone())
                 .ok_or(ReinstallError::NoRootPartition)?;
 
             let new_root = disks

--- a/src/installer/steps/configure.rs
+++ b/src/installer/steps/configure.rs
@@ -2,6 +2,7 @@ use envfile::EnvFile;
 use disk::Disks;
 use libc;
 use os_release::OsRelease;
+use partition_identity::{PartitionID, PartitionIDVariant};
 use std::fs::{self, Permissions};
 use std::io::{self, Write};
 use std::os::unix::ffi::OsStrExt;

--- a/src/installer/steps/configure.rs
+++ b/src/installer/steps/configure.rs
@@ -2,7 +2,7 @@ use envfile::EnvFile;
 use disk::Disks;
 use libc;
 use os_release::OsRelease;
-use partition_identity::{PartitionID, PartitionIDVariant};
+use partition_identity::PartitionID;
 use std::fs::{self, Permissions};
 use std::io::{self, Write};
 use std::os::unix::ffi::OsStrExt;
@@ -169,15 +169,15 @@ pub fn configure<P: AsRef<Path>, S: AsRef<str>, F: FnMut(i32)>(
 
         callback(20);
 
-        let luks_uuid = misc::from_uuid(&root_entry.uuid)
+        let luks_uuid = root_entry.uid.get_device_path()
             .and_then(|ref path| misc::resolve_to_physical(path.file_name().unwrap().to_str().unwrap()))
-            .and_then(|ref path| misc::get_uuid(path))
-            .and_then(|uuid| if uuid == root_entry.uuid { None } else { Some(uuid)});
+            .and_then(|ref path| PartitionID::get_uuid(path))
+            .and_then(|uuid| if uuid == root_entry.uid { None } else { Some(uuid)});
 
         callback(25);
 
-        let root_uuid = &root_entry.uuid;
-        update_recovery_config(&mount_dir, &root_uuid, luks_uuid.as_ref().map(|x| x.as_str()))?;
+        let root_uuid = &root_entry.uid;
+        update_recovery_config(&mount_dir, &root_uuid.id, luks_uuid.as_ref().map(|x| x.id.as_str()))?;
         callback(30);
 
         let (retain, lang_output) = rayon::join(
@@ -270,8 +270,8 @@ pub fn configure<P: AsRef<Path>, S: AsRef<str>, F: FnMut(i32)>(
         let recovery = chroot.recovery(
             config,
             &iso_os_release.name,
-            &root_uuid,
-            luks_uuid.as_ref().map_or("", |ref uuid| uuid.as_str())
+            &root_uuid.id,
+            luks_uuid.as_ref().map_or("", |ref uuid| uuid.id.as_str())
         );
 
         map_errors! {
@@ -307,7 +307,7 @@ pub fn configure<P: AsRef<Path>, S: AsRef<str>, F: FnMut(i32)>(
         // Ensure that the cdrom binding is unmounted before the chroot.
         if let Some((cdrom_mount, cdrom_target)) = cdrom_mount {
             drop(cdrom_mount);
-            fs::remove_dir(&cdrom_target);
+            let _ = fs::remove_dir(&cdrom_target);
         }
 
         drop(efivars_mount);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 extern crate fern;
+extern crate gettextrs;
+extern crate iso3166_1;
+extern crate isolang;
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
@@ -21,9 +24,7 @@ extern crate libc;
 extern crate libparted;
 #[macro_use]
 extern crate log;
-extern crate gettextrs;
-extern crate iso3166_1;
-extern crate isolang;
+extern crate partition_identity;
 extern crate rand;
 extern crate rayon;
 extern crate raw_cpuid;

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -126,47 +126,6 @@ pub fn get_file_hash<P: AsRef<Path>>(path: P, buffer: &mut [u8]) -> io::Result<u
     })
 }
 
-/// Obtains the UUID of the given device path by resolving symlinks in `/dev/disk/by-uuid`
-/// until the device is found.
-pub fn get_uuid(path: &Path) -> Option<String> {
-    let uuid_dir = Path::new("/dev/disk/by-uuid")
-        .read_dir()
-        .expect("unable to find /dev/disk/by-uuid");
-
-    if let Ok(path) = path.canonicalize() {
-        for uuid_entry in uuid_dir.filter_map(|entry| entry.ok()) {
-            if let Ok(ref uuid_path) = uuid_entry.path().canonicalize() {
-                if uuid_path == &path {
-                    if let Some(uuid_entry) = uuid_entry.file_name().to_str() {
-                        return Some(uuid_entry.into());
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}
-
-pub fn from_uuid(uuid: &str) -> Option<PathBuf> {
-    let uuid_dir = Path::new("/dev/disk/by-uuid")
-        .read_dir()
-        .expect("unable to find /dev/disk/by-uuid");
-
-    for uuid_entry in uuid_dir.filter_map(|entry| entry.ok()) {
-        let uuid_entry = uuid_entry.path();
-        if let Some(name) = uuid_entry.file_name() {
-            if name == uuid {
-                if let Ok(uuid_entry) = uuid_entry.canonicalize() {
-                    return Some(uuid_entry);
-                }
-            }
-        }
-    }
-
-    None
-}
-
 /// Concatenates an array of `&OsStr` into a new `OsString`.
 pub(crate) fn concat_osstr(input: &[&OsStr]) -> OsString {
     let mut output = OsString::with_capacity(input.iter().fold(0, |acc, c| acc + c.len()));

--- a/src/mnt/mounts.rs
+++ b/src/mnt/mounts.rs
@@ -85,10 +85,17 @@ impl MountList {
         Self::parse_from(file.lines())
     }
 
-    pub(crate) fn get_mount_point(&self, path: &Path) -> Option<PathBuf> {
+    pub(crate) fn find_mount<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
         self.0
             .iter()
-            .find(|mount| mount.source == path)
+            .find(|mount| mount.dest == path.as_ref())
+            .map(|mount| mount.source.clone())
+    }
+
+    pub(crate) fn get_mount_point<P: AsRef<Path>>(&self, path: P) -> Option<PathBuf> {
+        self.0
+            .iter()
+            .find(|mount| mount.source == path.as_ref())
             .map(|mount| mount.dest.clone())
     }
 


### PR DESCRIPTION
Closes #146 

### Changes

- Due to the possibility of UUID collisions when creating FAT partitions, new installs will use `PARTUUID=${UID}` in `/etc/fstab` for FAT partitions instead of UUID.
- The `recovery.conf` file will now add `PARTUUID=` to the values of the `EFI_UUID` and `RECOVERY_UUID` variables.
- The recovery option will search for the presence of `PARTUUID=`, and then will mount the devices by either the PartUUID or the original UUID behavior.
- Removes the `misc::from_uuid` / `misc::get_uuid` functions and has their functionality improved in our new [partition-identity crate](https://github.com/pop-os/partition-identity).

### Testing

- Verify that the `/etc/fstab` file is mounting the efi and recovery partition by PARTUUID
- Verify that a normal and recovery install works