### PR TITLE
Fix `Command::run()` to retain the `NotFound` error kind

### DIFF
--- a/src/process/command.rs
+++ b/src/process/command.rs
@@ -98,6 +98,11 @@ impl Command {
 
         if status.success() {
             Ok(())
+        } else if let Some(127) = status.code() {
+            Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("command {} was not found", cmd)
+            ))
         } else {
             Err(io::Error::new(
                 io::ErrorKind::Other,


### PR DESCRIPTION
- The original I/O error kind will now be forwarded
- Adds unit tests to ensure that the behavior works
- Fixes BIOS installations
