### PR TITLE
Do not set nvram variables when using grub-install, as this is done later with efibootmgr

### DIFF
--- a/src/installer/steps/bootloader.rs
+++ b/src/installer/steps/bootloader.rs
@@ -104,6 +104,7 @@ pub fn bootloader<F: FnMut(i32)>(
                                 "--efi-directory=/boot/efi",
                                 &format!("--boot-directory=/boot/efi/EFI/{}", name),
                                 &format!("--bootloader={}", name),
+                                "--no-nvram",
                                 "--recheck",
                             ]
                         ).run()?;


### PR DESCRIPTION
This should fix trubble imaging of Ubuntu