### PR TITLE
Hide read-only devices from install options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "disk-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -278,7 +278,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cascade 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "distinst-bootloader 0.1.0",
  "distinst-chroot 0.1.0",
  "distinst-disks 0.1.0",
@@ -327,7 +327,7 @@ name = "distinst-disk-ops"
 version = "0.1.0"
 dependencies = [
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "distinst-bootloader 0.1.0",
  "distinst-external-commands 0.1.0",
  "libparted 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -344,7 +344,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "distinst-bootloader 0.1.0",
  "distinst-disk-ops 0.1.0",
  "distinst-external-commands 0.1.0",
@@ -371,7 +371,7 @@ dependencies = [
 name = "distinst-external-commands"
 version = "0.1.0"
 dependencies = [
- "disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "distinst-utils 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-mounts 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -518,7 +518,7 @@ name = "fstab-generate"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "partition-identity 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1391,7 +1391,7 @@ dependencies = [
 "checksum dbus 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e34c238dfb3f5881d46ad301403cd8f8ecf946e2a4e89bdd1166728b68b5008"
 "checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
-"checksum disk-types 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a915a55fc365dfd890baccc4d7be373fae1d2e991814e83b07b343bfd3c8b6"
+"checksum disk-types 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "87862c602e07fb41380cd67321cd383a37e98ac0d2f80b83e2cea2d1e58799de"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum envfile 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "417b5f7494d642249d369a673196c3d3576eac6abd6063664347d2bfe74fc86d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pbr = "1.0.1"
 [dependencies]
 cascade = "0.1.2"
 dirs = "1.0.3"
-disk-types = "0.1.0"
+disk-types = "0.1.2"
 distinst-bootloader = { path = "crates/bootloader" }
 distinst-chroot = { path = "crates/chroot" }
 distinst-disks = { path = "crates/disks" }

--- a/crates/disk-ops/Cargo.toml
+++ b/crates/disk-ops/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["filesystem", "os"]
 [dependencies]
 distinst-bootloader = { path = "../bootloader" }
 derive-new = "0.5.5"
-disk-types = "0.1.0"
+disk-types = "0.1.2"
 distinst-external-commands = { path = "../external" }
 log = "0.4.6"
 tempdir = "0.3.7"

--- a/crates/disks/Cargo.toml
+++ b/crates/disks/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["filesystem", "os"]
 [dependencies]
 bitflags = "1.0.4"
 derive-new = "0.5.5"
-disk-types = "0.1.0"
+disk-types = "0.1.2"
 distinst-bootloader = { path = "../bootloader" }
 distinst-disk-ops = { path = "../disk-ops" }
 distinst-external-commands = { path = "../external" }

--- a/crates/disks/src/config/disk.rs
+++ b/crates/disks/src/config/disk.rs
@@ -112,6 +112,10 @@ impl BlockDeviceExt for Disk {
     fn get_device_path(&self) -> &Path { &self.device_path }
 
     fn get_mount_point(&self) -> Option<&Path> { self.mount_point.as_ref().map(|x| x.as_path()) }
+
+    fn is_read_only(&self) -> bool {
+        self.read_only
+    }
 }
 
 impl SectorExt for Disk {

--- a/crates/external/Cargo.toml
+++ b/crates/external/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 keywords = ["distinst", "external", "commands"]
 
 [dependencies]
-disk-types = "0.1.0"
+disk-types = "0.1.2"
 distinst-utils = { path = "../utils" }
 log = "0.4.5"
 proc-mounts = "0.1.0"

--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -772,6 +772,11 @@ namespace Distinst {
         public bool contains_mount (string mount, Distinst.Disks disks);
 
         /**
+         * Returns true if the device is read-only
+         */
+        public bool is_read_only ();
+
+        /**
          * Returns true if the device is a removable device.
          */
         public bool is_removable ();

--- a/ffi/src/disk.rs
+++ b/ffi/src/disk.rs
@@ -155,6 +155,16 @@ pub unsafe extern "C" fn distinst_disk_contains_mount(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn distinst_disk_is_read_only(disk: *mut DistinstDisk) -> bool {
+    if null_check(disk).is_err() {
+        return false;
+    }
+
+    let disk = &mut *(disk as *mut Disk);
+    disk.is_read_only()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn distinst_disk_is_removable(disk: *mut DistinstDisk) -> bool {
     if null_check(disk).is_err() {
         return false;

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -72,10 +72,18 @@ impl InstallOptions {
             };
 
             for device in disks.get_physical_devices() {
-                let has_recovery = !Path::new("/cdrom/recovery.conf").exists()
-                    && (device.contains_mount("/", &disks) || device.contains_mount("/cdrom", &disks));
+                // A device should be ignored if it is read-oly, or happens to be mounted at
+                // either `/`, or `/cdrom`, with the exception of being in recovery mode.
+                let ignore = device.is_read_only()
+                    || (
+                        ! Path::new("/cdrom/recovery.conf").exists()
+                            && (
+                                device.contains_mount("/", &disks)
+                                || device.contains_mount("/cdrom", &disks)
+                            )
+                    );
 
-                if has_recovery {
+                if ignore {
                     continue
                 }
 


### PR DESCRIPTION
Devices like `/dev/sr0` will no longer appear as an erase option, due to their read-only status.