### PR TITLE
Casper cannot find the recovery partition if there's a duplicate UUID

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -34,7 +34,7 @@ impl<'a> ChrootConfigurator<'a> {
             ..extend_from_slice(APT_OPTIONS);
             ..extend_from_slice(&packages);
         });
-        
+
         command.stdout(Stdio::null());
         command.run()
     }
@@ -321,12 +321,13 @@ OEM_MODE=0
         let rec_entry_data = format!(r#"title {0} recovery
 linux /EFI/{1}/vmlinuz.efi
 initrd /EFI/{1}/initrd.gz
-options {2} boot=casper hostname=recovery userfullname=Recovery username=recovery live-media-path=/{3} noprompt
+options {2} boot=casper hostname=recovery userfullname=Recovery username=recovery live-media-path=/{3} live-media=/dev/disk/by-partuuid/{4} noprompt
 "#,
             name,
             recovery,
             BOOT_OPTIONS,
-            casper
+            casper,
+            recovery_partuuid.id
         );
         let loader_entries = self.chroot.path.join("boot/efi/loader/entries/");
         if ! loader_entries.exists() {


### PR DESCRIPTION
When two UUIDs are the same, there's a risk that casper will not be able to find the block device with the specified casper directory. Testing found that the only way to get the recovery partition to boot was to set `live-media=/dev/disk/by-partuuid/${PARTUUID}` as one of the kernel options, to avoid the scan entirely.

@brs17 Testing this should be as simple as seeing if an install works with differing UUIDs, and if it also works when they are the same.