### PR TITLE
Add correct kernel for Ubuntu 18.04

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -101,6 +101,10 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
     match Bootloader::detect() {
         Bootloader::Bios => &["grub-pc"],
         Bootloader::Efi if os_release.name == "Pop!_OS" => &["kernelstub"],
+        Bootloader::Efi if os_release.name == "Ubuntu" && os_release.version_id == "18.04" => {
+            &["grub-efi", "grub-efi-amd64", "grub-efi-amd64-signed",
+              "shim-signed", "mokutil", "fwupdate-signed", "linux-signed-generic-hwe-18.04"]
+        },
         Bootloader::Efi => {
             &["grub-efi", "grub-efi-amd64", "grub-efi-amd64-signed",
               "shim-signed", "mokutil", "fwupdate-signed", "linux-signed-generic"]


### PR DESCRIPTION
This fixes installing Ubuntu 18.04.2 with distinst. Regression potential extremely low, and only affects imaging systems using Ubuntu. I am looking to get this out ASAP so Ubuntu imaging can be re-enabled.