### PR TITLE
Use dpkg instead of apt-get for package purging

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -57,10 +57,10 @@ impl<'a> ChrootConfigurator<'a> {
         info!("removing packages: {:?}", packages);
         self.chroot
             .command(
-                "apt-get",
+                "dpkg",
                 &cascade! {
-                    Vec::with_capacity(packages.len() + 2);
-                    ..extend_from_slice(&["purge", "-y"]);
+                    Vec::with_capacity(packages.len() + 1);
+                    ..push("--purge");
                     ..extend_from_slice(packages);
                 },
             )


### PR DESCRIPTION
Fixes #207 

This doesn't fail if a package in the list isn't installed. For example, see the following terminal output:

```
david@david-XPS-13-9343:~/Documents/Projects/appcenter/build$ sudo dpkg --purge fakepackagename
dpkg: warning: ignoring request to remove fakepackagename which isn't installed
david@david-XPS-13-9343:~/Documents/Projects/appcenter/build$ echo $?
0
david@david-XPS-13-9343:~/Documents/Projects/appcenter/build$ sudo apt-get purge -y fakepackagename
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package fakepackagename
david@david-XPS-13-9343:~/Documents/Projects/appcenter/build$ echo $?
100
```