### PR TITLE
Only remove kernelstub on Pop!_OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "apt-cli-wrappers"
 version = "0.1.0"
 source = "git+https://github.com/pop-os/apt-cli-wrappers#7ea2fd5e91d8076dab789d3015e0a1ffc9525ecb"
@@ -310,6 +315,7 @@ dependencies = [
 name = "distinst"
 version = "0.5.0"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "apt-cli-wrappers 0.1.0 (git+https://github.com/pop-os/apt-cli-wrappers)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cascade 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1599,6 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum apt-cli-wrappers 0.1.0 (git+https://github.com/pop-os/apt-cli-wrappers)" = "<none>"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,13 +62,14 @@ os-release = "0.1.0"
 partition-identity = "0.2.2"
 proc-mounts = "0.1.2"
 rayon = "1.0.2"
-sys-mount = "1.1.0"
+sys-mount = "1"
 tempdir = "0.3.7"
 bitflags = "1.0.4"
 err-derive = "0.1.5"
 apt-cli-wrappers = { git = "https://github.com/pop-os/apt-cli-wrappers" }
 systemd-boot-conf = "0.1.0"
 derive_more = "0.99.2"
+anyhow = "1"
 
 [dependencies.failure]
 version = "0.1.2"

--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -1075,6 +1075,13 @@ namespace Distinst {
 
     public delegate UserAccountCreate UserAccountCallback ();
 
+    /**
+     * Attempts to unset the active mode
+     *
+     * Returns `false` on an error. See distinst logs for details on the cause of the error.
+     */
+    bool unset_mode ();
+
     int log (Distinst.LogCallback callback);
 
     [Compact]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -97,6 +97,17 @@ pub unsafe extern "C" fn distinst_validate_hostname(hostname: *const libc::c_cha
 #[no_mangle]
 pub extern "C" fn distinst_minimum_disk_size(size: u64) -> u64 { distinst::minimum_disk_size(size) }
 
+#[no_mangle]
+pub extern "C" fn distinst_unset_mode() -> bool {
+    match distinst::unset_mode() {
+        Ok(()) => true,
+        Err(why) => {
+            error!("unset_mode: ${:?}", why);
+            false
+        }
+    }
+}
+
 /// Log level
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -105,6 +105,15 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
             "fwupdate-signed",
             "linux-signed-generic-hwe-18.04",
         ],
+        Bootloader::Efi if os_release.name == "Ubuntu" && os_release.version_id == "20.04" => &[
+            "grub-efi",
+            "grub-efi-amd64",
+            "grub-efi-amd64-signed",
+            "shim-signed",
+            "mokutil",
+            "fwupd-signed",
+            "linux-image-generic",
+        ],
         Bootloader::Efi => &[
             "grub-efi",
             "grub-efi-amd64",

--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -57,10 +57,10 @@ impl<'a> ChrootConfigurator<'a> {
         info!("removing packages: {:?}", packages);
         self.chroot
             .command(
-                "apt-get",
+                "dpkg",
                 &cascade! {
-                    Vec::with_capacity(packages.len() + 2);
-                    ..extend_from_slice(&["purge", "-y"]);
+                    Vec::with_capacity(packages.len() + 1);
+                    ..push("--purge");
                     ..extend_from_slice(packages);
                 },
             )

--- a/src/installer/steps/configure/mod.rs
+++ b/src/installer/steps/configure/mod.rs
@@ -231,7 +231,7 @@ pub fn configure<D: InstallerDiskOps, P: AsRef<Path>, S: AsRef<str>, F: FnMut(i3
 
         // Remove incompatible bootloader packages
         match Bootloader::detect() {
-            Bootloader::Bios => remove.push("kernelstub"),
+            Bootloader::Bios if iso_os_release.name == "Pop!_OS" => remove.push("kernelstub"),
             Bootloader::Efi => (),
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub extern crate partition_identity;
 pub extern crate proc_mounts;
 pub extern crate sys_mount;
 
+extern crate anyhow;
 extern crate apt_cli_wrappers;
 #[macro_use]
 extern crate bitflags;
@@ -68,12 +69,17 @@ pub mod dbus_interfaces {
     pub use logind_dbus::*;
 }
 
-use external::dmlist;
 use std::{
     io::{self, Read},
     path::{Path, PathBuf},
     sync::atomic::AtomicBool,
 };
+
+use anyhow::Context;
+use external::dmlist;
+use partition_identity::PartitionID;
+use sys_mount::*;
+use systemd_boot_conf::SystemdBootConf;
 
 pub use self::{installer::*, logging::log};
 
@@ -122,4 +128,38 @@ pub fn minimum_disk_size(default: u64) -> u64 {
         .map_or(default, |size| size.max(default));
 
     casper_size + DEFAULT_ESP_SECTORS + DEFAULT_RECOVER_SECTORS + DEFAULT_SWAP_SECTORS
+}
+
+pub fn unset_mode() -> anyhow::Result<()> {
+    let mut conf = RecoveryEnv::new().context("failed to read recovery.conf")?;
+
+    if conf.get("MODE") == Some("refresh") {
+        let efi_id = conf.get("EFI_UUID").context("EFI_UUID is not set")?;
+        let prev_boot = conf.get("PREV_BOOT").context("PREV_BOOT is not set")?;
+
+        let efi_pid = if efi_id.starts_with("PARTUUID=") {
+            PartitionID::new_partuuid(efi_id[9..].to_owned())
+        } else {
+            PartitionID::new_uuid(efi_id.to_owned())
+        };
+
+        let efi_path =
+            efi_pid.get_device_path().context("failed to get device path from EFI partition")?;
+
+        let _mount = Mount::new(&efi_path, "target", "vfat", MountFlags::empty(), None)
+            .context("failed to mount EFI partition")?
+            .into_unmount_drop(UnmountFlags::DETACH);
+
+        let mut boot_loader =
+            SystemdBootConf::new("target").context("failed to open boot loader conf")?;
+
+        boot_loader.loader_conf.default = Some(prev_boot.into());
+        boot_loader.overwrite_loader_conf().context("failed to overwrite boot loader conf")?;
+
+        conf.remove("MODE");
+        conf.remove("PREV_BOOT");
+        conf.write().context("failed to write updated boot loader conf")?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
Alternative fix for #207 

https://github.com/pop-os/distinst/commit/650984da73ddf7f4b44d024fb5d80503529305e3 should probably be reverted as it is causing dependency issues in our 20.04 test builds