### PR TITLE
Support elementary OS 6.0

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -114,6 +114,15 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
             "fwupd-signed",
             "linux-image-generic",
         ],
+        Bootloader::Efi if os_release.name == "elementary OS" && os_release.version_id == "6.0" => &[
+            "grub-efi",
+            "grub-efi-amd64",
+            "grub-efi-amd64-signed",
+            "shim-signed",
+            "mokutil",
+            "fwupd-signed",
+            "linux-image-generic",
+        ],
         Bootloader::Efi => &[
             "grub-efi",
             "grub-efi-amd64",


### PR DESCRIPTION
Same packages as Ubuntu 20.04, I don't know if there's some magic syntax you can use to use the same list for both conditions.