### PR TITLE
fix: Specify 'plain' in cryptswap line of /etc/crypttab

### DIFF
--- a/src/installer/traits.rs
+++ b/src/installer/traits.rs
@@ -119,7 +119,7 @@ impl InstallerDiskOps for Disks {
                             crypttab.push(" UUID=");
                             crypttab.push(&uuid.id);
                             crypttab.push(
-                                " /dev/urandom swap,offset=1024,cipher=aes-xts-plain64,size=512\n",
+                                " /dev/urandom swap,plain,offset=1024,cipher=aes-xts-plain64,size=512\n",
                             );
 
                             fstab.push(


### PR DESCRIPTION
Matches https://github.com/pop-os/upgrade/pull/126.

This should change no behavior (other than warnings) since 'plain' is the default.