### PR TITLE
fix: Be less strict about elementary OS versions

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -114,14 +114,12 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
             "fwupd-signed",
             "linux-image-generic",
         ],
-        Bootloader::Efi if os_release.name == "elementary OS" && os_release.version_id == "6.0" => &[
+        Bootloader::Efi if os_release.name == "elementary OS" => &[
             "grub-efi",
             "grub-efi-amd64",
             "grub-efi-amd64-signed",
             "shim-signed",
             "mokutil",
-            "fwupd-signed",
-            "linux-image-generic",
         ],
         Bootloader::Efi => &[
             "grub-efi",


### PR DESCRIPTION
Question before merging:

Why are `fwupd-signed` and `linux-image-generic` in the list of packages for the bootloader here? This was originally copied from the Ubuntu 18.04 code, but surely the kernel and fwupd already exist in the squashfs which gets deployed to the install, so why install them again at the bootloader stage?

We're happy to give this a test with those packages removed as it means less changes needed here if we want to switch to a different kernel package for HWE or w/e.