### PR TITLE
Upgrade to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 license = "LGPL-3.0"
 readme = "README.md"
+edition = "2018"
 
 [workspace]
 members = [

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 license = "LGPL-3.0"
 readme = "README.md"
+edition = "2018"
 
 [[bin]]
 name = "distinst"

--- a/crates/bootloader/Cargo.toml
+++ b/crates/bootloader/Cargo.toml
@@ -8,5 +8,6 @@ readme = "README.md"
 license = "MIT"
 keywords =  ["efi", "mbr", "bootloader", "distinst"]
 categories = ["os", "os::unix-apis"]
+edition = "2018"
 
 [dependencies]

--- a/crates/chroot/Cargo.toml
+++ b/crates/chroot/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 keywords =  ["chroot", "command", "process", "distinst"]
 categories = ["os", "os::unix-apis"]
+edition = "2018"
 
 [dependencies]
 sys-mount = "1.2.1"

--- a/crates/chroot/src/chroot.rs
+++ b/crates/chroot/src/chroot.rs
@@ -5,7 +5,7 @@ use std::{
     process::Stdio,
 };
 use sys_mount::*;
-use Command;
+use crate::command::Command;
 
 /// Defines the location where a `chroot` will be performed, as well as storing
 /// handles to all of the binding mounts that the chroot requires.

--- a/crates/chroot/src/sd_nspawn.rs
+++ b/crates/chroot/src/sd_nspawn.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
     process::Stdio,
 };
-use Command;
+use crate::command::Command;
 
 /// Defines the location where a `chroot` will be performed, with `systemd-nspawn`.
 pub struct SystemdNspawn<'a> {

--- a/crates/disk-ops/Cargo.toml
+++ b/crates/disk-ops/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 keywords =  ["disk", "partition"]
 categories = ["filesystem", "os"]
+edition = "2018"
 
 [dependencies]
 distinst-bootloader = { path = "../bootloader" }

--- a/crates/disk-ops/src/mklabel.rs
+++ b/crates/disk-ops/src/mklabel.rs
@@ -1,7 +1,7 @@
 use disk_types::PartitionTable;
 use external::wipefs;
 use libparted::{Disk as PedDisk, DiskType as PedDiskType};
-use parted::*;
+use crate::parted::*;
 use std::{
     fs::File,
     io::{self, Seek, SeekFrom, Write},

--- a/crates/disk-ops/src/mkpart.rs
+++ b/crates/disk-ops/src/mkpart.rs
@@ -3,7 +3,7 @@ use libparted::{
     Device, FileSystemType as PedFileSystem, Geometry, Partition as PedPartition, PartitionFlag,
     PartitionType as PedPartitionType,
 };
-use parted::*;
+use crate::parted::*;
 use std::{
     io,
     path::{Path, PathBuf},

--- a/crates/disks/Cargo.toml
+++ b/crates/disks/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 keywords =  ["distinst", "disk", "management", "partition"]
 categories = ["filesystem", "os"]
+edition = "2018"
 
 [dependencies]
 bitflags = "1.2.1"

--- a/crates/disks/src/config/disk.rs
+++ b/crates/disks/src/config/disk.rs
@@ -7,7 +7,7 @@ use super::{
     PVS,
 };
 use disk_types::{PartitionExt, PartitionTableExt, SectorExt};
-use external::{is_encrypted, pvs};
+use crate::external::{is_encrypted, pvs};
 use libparted::{Device, DeviceType, Disk as PedDisk};
 use operations::{
     parted::{get_device, open_disk},

--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -8,7 +8,7 @@ use super::{
     Disk, LvmEncryption, PartitionTable, PVS,
 };
 use disk_types::{BlockDeviceExt, PartitionExt, PartitionTableExt, SectorExt};
-use external::{
+use crate::external::{
     cryptsetup_close, cryptsetup_open, lvs, physical_volumes_to_deactivate, pvs, vgdeactivate,
     CloseBy,
 };

--- a/crates/disks/src/config/lvm/encryption.rs
+++ b/crates/disks/src/config/lvm/encryption.rs
@@ -1,9 +1,9 @@
-use external::{cryptsetup_encrypt, cryptsetup_open, pvcreate};
+use crate::external::{cryptsetup_encrypt, cryptsetup_open, pvcreate};
 use std::{
     fmt,
     path::{Path, PathBuf},
 };
-use DiskError;
+use crate::DiskError;
 
 /// A structure which contains the encryption settings for a physical volume.
 #[derive(Clone, PartialEq)]

--- a/crates/disks/src/config/lvm/mod.rs
+++ b/crates/disks/src/config/lvm/mod.rs
@@ -9,8 +9,8 @@ use super::{
     get_size,
 };
 use disk_types::{BlockDeviceExt, PartitionExt, PartitionTableExt, SectorExt};
-pub use external::deactivate_devices;
-use external::{blkid_partition, lvcreate, lvremove, lvs, mkfs, vgactivate, vgcreate};
+pub use crate::external::deactivate_devices;
+use crate::external::{blkid_partition, lvcreate, lvremove, lvs, mkfs, vgactivate, vgcreate};
 use partition_identity::PartitionIdentifiers;
 use proc_mounts::MOUNTS;
 use std::{

--- a/crates/disks/src/config/partitions/mod.rs
+++ b/crates/disks/src/config/partitions/mod.rs
@@ -6,7 +6,7 @@ use super::{
     PVS,
 };
 pub use disk_types::{BlockDeviceExt, FileSystem, PartitionExt, PartitionType};
-use external::{get_label, is_encrypted};
+use crate::external::{get_label, is_encrypted};
 use fstab_generate::BlockInfo;
 use libparted::{Partition, PartitionFlag};
 pub use os_detect::OS;

--- a/crates/disks/src/external.rs
+++ b/crates/disks/src/external.rs
@@ -1,6 +1,6 @@
 //! A collection of external commands used throughout the program.
 
-pub use config::deactivate_devices;
+pub use crate::config::deactivate_devices;
 pub use external_::*;
 use misc;
 use proc_mounts::{MountList, SwapList};
@@ -12,7 +12,7 @@ use std::{
 };
 use sys_mount::*;
 use tempdir::TempDir;
-use LvmEncryption;
+use crate::LvmEncryption;
 
 fn remove_encrypted_device(device: &Path) -> io::Result<()> {
     let mounts = MountList::new().expect("failed to get mounts in deactivate_device_maps");

--- a/crates/external/Cargo.toml
+++ b/crates/external/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/pop-os/distinst"
 readme = "README.md"
 license = "MIT"
 keywords = ["distinst", "external", "commands"]
+edition = "2018"
 
 [dependencies]
 disk-types = "=0.1.2"

--- a/crates/external/src/block.rs
+++ b/crates/external/src/block.rs
@@ -1,7 +1,7 @@
 use self::FileSystem::*;
 use super::exec;
 use disk_types::FileSystem;
-use retry::Retry;
+use crate::retry::Retry;
 use std::{
     ffi::{OsStr, OsString},
     io,

--- a/crates/hardware/Cargo.toml
+++ b/crates/hardware/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 categories = ["os", "os::unix-apis"]
 keywords = ["linux", "hardware", "support"]
+edition = "2018"
 
 [dependencies]
 distinst-utils = { path = "../utils" }

--- a/crates/locales/Cargo.toml
+++ b/crates/locales/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 license = "MIT"
 categories = ["os::unix-apis", "localization"]
 keywords = ["distinst", "linux", "locale", "keyboard", "language", "country"]
+edition = "2018"
 
 [dependencies]
 distinst-utils = { path = "../utils/" }

--- a/crates/squashfs/Cargo.toml
+++ b/crates/squashfs/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/pop-os/distinst"
 readme = "README.md"
 license = "MIT"
 keywords = ["squashfs"]
+edition = "2018"
 
 [dependencies]
 libc = "0.2.68"

--- a/crates/timezones/Cargo.toml
+++ b/crates/timezones/Cargo.toml
@@ -2,5 +2,6 @@
 name = "distinst-timezones"
 version = "0.1.0"
 authors = ["Michael Aaron Murphy <mmstickman@gmail.com>"]
+edition = "2018"
 
 [dependencies]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/pop-os/distinst"
 readme = "README.md"
 license = "MIT"
 keywords = ["distinst", "utils"]
+edition = "2018"
 
 [dependencies]
 sedregex = "0.2.4"

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Architecture: amd64
 Depends:
   libdistinst (= ${binary:Version}),
   ${misc:Depends},
-  ${shlib:Depends}
+  ${shlibs:Depends}
 Description: Distribution Installer CLI
 
 Package: libdistinst
@@ -50,7 +50,7 @@ Depends:
   util-linux,
   xfsprogs,
   ${misc:Depends},
-  ${shlib:Depends}
+  ${shlibs:Depends}
 Description: Distribution Installer Library
 
 Package: libdistinst-dev

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 license = "LGPL-3.0"
 readme = "README.md"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "distinst"

--- a/ffi/src/config.rs
+++ b/ffi/src/config.rs
@@ -1,5 +1,5 @@
 use distinst::{Config, UserAccountCreate};
-use get_str;
+use crate::get_str;
 use libc;
 use std::io;
 

--- a/ffi/src/disk.rs
+++ b/ffi/src/disk.rs
@@ -14,16 +14,16 @@ use distinst::{
 };
 
 use super::{get_str, null_check};
-use ffi::AsMutPtr;
-use filesystem::DISTINST_FILE_SYSTEM;
-use gen_object_ptr;
-use lvm::{DistinstLvmDevice, DistinstLvmEncryption};
-use partition::{
+use crate::ffi::AsMutPtr;
+use crate::filesystem::DISTINST_FILE_SYSTEM;
+use crate::gen_object_ptr;
+use crate::lvm::{DistinstLvmDevice, DistinstLvmEncryption};
+use crate::partition::{
     DistinstPartition, DistinstPartitionAndDiskPath, DistinstPartitionBuilder,
     DISTINST_PARTITION_TABLE,
 };
-use partition_identity::PartitionID;
-use sector::DistinstSector;
+use crate::partition_identity::PartitionID;
+use crate::sector::DistinstSector;
 
 #[repr(C)]
 pub struct DistinstDisk;

--- a/ffi/src/installer.rs
+++ b/ffi/src/installer.rs
@@ -2,12 +2,12 @@ use libc;
 
 use std::io;
 
-use config::DistinstConfig;
-use disk::DistinstDisks;
+use crate::config::DistinstConfig;
+use crate::disk::DistinstDisks;
 use distinst::{timezones::Region, Disks, Error, Installer, Status, Step};
-use gen_object_ptr;
-use DistinstRegion;
-use DistinstUserAccountCreate;
+use crate::gen_object_ptr;
+use crate::DistinstRegion;
+use crate::DistinstUserAccountCreate;
 
 /// Bootloader steps
 #[repr(C)]

--- a/ffi/src/lvm.rs
+++ b/ffi/src/lvm.rs
@@ -3,7 +3,7 @@ use distinst::{
     SectorExt,
 };
 use external::luks::deactivate_logical_devices;
-use ffi::AsMutPtr;
+use crate::ffi::AsMutPtr;
 use libc;
 
 use super::{

--- a/ffi/src/partition.rs
+++ b/ffi/src/partition.rs
@@ -6,11 +6,11 @@ use distinst::{
     BlockDeviceExt, Bootloader, FileSystem, LvmEncryption, PartitionBuilder, PartitionExt,
     PartitionFlag, PartitionInfo, PartitionTable, PartitionType,
 };
-use filesystem::DISTINST_FILE_SYSTEM;
-use gen_object_ptr;
-use get_str;
-use null_check;
-use DistinstLvmEncryption;
+use crate::filesystem::DISTINST_FILE_SYSTEM;
+use crate::gen_object_ptr;
+use crate::get_str;
+use crate::null_check;
+use crate::DistinstLvmEncryption;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]

--- a/ffi/src/sector.rs
+++ b/ffi/src/sector.rs
@@ -1,8 +1,8 @@
 use distinst::Sector;
-use get_str;
+use crate::get_str;
 use libc;
 use std::ptr;
-use to_cstr;
+use crate::to_cstr;
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/ffi/src/timezones.rs
+++ b/ffi/src/timezones.rs
@@ -1,5 +1,5 @@
 use distinst::timezones::*;
-use gen_object_ptr;
+use crate::gen_object_ptr;
 use libc;
 use std::ptr;
 

--- a/src/auto/accounts.rs
+++ b/src/auto/accounts.rs
@@ -4,7 +4,7 @@ use super::{mount_and_then, ReinstallError};
 use disk_types::FileSystem;
 use std::{collections::HashMap, ffi::OsStr, os::unix::ffi::OsStrExt, path::Path};
 
-use misc::read;
+use crate::misc::read;
 
 #[derive(Default, Debug)]
 pub struct AccountFiles {

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -39,7 +39,7 @@ pub enum ReinstallError {
     #[fail(display = "supplied disk configuration will format /home when it should not")]
     ReformattingHome,
     #[fail(display = "unable to probe existing devices: {}", why)]
-    DiskProbe { why: ::disks::DiskError },
+    DiskProbe { why: crate::disks::DiskError },
     #[fail(display = "invalid partition configuration: {}", why)]
     InvalidPartitionConfiguration { why: io::Error },
     #[fail(display = "install media at {:?} was not found", path)]

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -6,8 +6,8 @@ use super::{
 };
 use disk_types::{FileSystem::*, SectorExt};
 
-use external::{generate_unique_id, remount_rw};
-use misc;
+use crate::external::{generate_unique_id, remount_rw};
+use crate::misc;
 use partition_identity::PartitionID;
 use proc_mounts::MountIter;
 

--- a/src/auto/retain.rs
+++ b/src/auto/retain.rs
@@ -1,12 +1,12 @@
 //! Retain users when reinstalling, keeping their home folder and user account.
 
-use bootloader::Bootloader;
+use crate::bootloader::Bootloader;
 use disk_types::FileSystem;
-use disks::Disks;
+use crate::disks::Disks;
 
 use super::{mount_and_then, AccountFiles, ReinstallError, UserData};
 
-use misc;
+use crate::misc;
 use std::{
     ffi::{OsStr, OsString},
     fs::{self, File, OpenOptions, Permissions},

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -1,6 +1,6 @@
-use bootloader::Bootloader;
-use chroot::Chroot;
-use installer::{bitflags::FileSystemSupport, traits::InstallerDiskOps};
+use crate::bootloader::Bootloader;
+use crate::chroot::Chroot;
+use crate::installer::{bitflags::FileSystemSupport, traits::InstallerDiskOps};
 use os_release::OsRelease;
 use std::{
     collections::HashSet,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use disks::DiskError;
+use crate::disks::DiskError;
 use std::{error::Error, fmt::Display, io};
 
 /// Extends `Option<T>` to be converted into an `io::Result<T>`.

--- a/src/installer/conf.rs
+++ b/src/installer/conf.rs
@@ -1,5 +1,5 @@
 use envfile::EnvFile;
-use errors::IoContext;
+use crate::errors::IoContext;
 use std::io;
 
 #[derive(AsMut, Deref, DerefMut)]

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -10,26 +10,26 @@ pub use self::{conf::RecoveryEnv, steps::Step};
 
 use self::state::InstallerState;
 
-use auto::{
+use crate::auto::{
     delete_old_install, move_root, recover_root, remove_root, validate_backup_conditions,
     AccountFiles, Backup, ReinstallError,
 };
 use disk_types::BlockDeviceExt;
-use disks::{Bootloader, Disks};
-use errors::IoContext;
-use external::luks::deactivate_logical_devices;
-use hostname;
+use crate::disks::{Bootloader, Disks};
+use crate::errors::IoContext;
+use crate::external::luks::deactivate_logical_devices;
+use crate::hostname;
 use os_release::OsRelease;
 use partition_identity::PartitionID;
-use squashfs;
+use crate::squashfs;
 use std::{
     io,
     path::{Path, PathBuf},
     sync::atomic::Ordering,
 };
 use tempdir::TempDir;
-use timezones::Region;
-use PARTITIONING_TEST;
+use crate::timezones::Region;
+use crate::PARTITIONING_TEST;
 
 pub const MODIFY_BOOT_ORDER: u8 = 0b01;
 pub const INSTALL_HARDWARE_SUPPORT: u8 = 0b10;

--- a/src/installer/state.rs
+++ b/src/installer/state.rs
@@ -1,7 +1,7 @@
 use super::{Error, Installer, Status, Step};
 use libc;
 use std::{io, sync::atomic::Ordering};
-use KILL_SWITCH;
+use crate::KILL_SWITCH;
 
 pub struct InstallerState<'a> {
     pub installer: &'a mut Installer,

--- a/src/installer/steps/bootloader.rs
+++ b/src/installer/steps/bootloader.rs
@@ -1,6 +1,6 @@
-use chroot::Chroot;
-use disks::{Bootloader, Disks};
-use errors::IoContext;
+use crate::chroot::Chroot;
+use crate::disks::{Bootloader, Disks};
+use crate::errors::IoContext;
 use libc;
 use os_release::OsRelease;
 use std::{
@@ -9,8 +9,8 @@ use std::{
     os::unix::ffi::{OsStrExt, OsStringExt},
     path::{Path, PathBuf},
 };
-use Config;
-use MODIFY_BOOT_ORDER;
+use crate::Config;
+use crate::MODIFY_BOOT_ORDER;
 
 use super::mount_efivars;
 

--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -1,6 +1,6 @@
-use chroot::{Chroot, Command};
-use errors::IoContext;
-use misc;
+use crate::chroot::{Chroot, Command};
+use crate::errors::IoContext;
+use crate::misc;
 use partition_identity::PartitionID;
 use proc_mounts::MountList;
 use std::{
@@ -10,8 +10,8 @@ use std::{
     process::Stdio,
 };
 use sys_mount::*;
-use timezones::Region;
-use Config;
+use crate::timezones::Region;
+use crate::Config;
 
 const APT_OPTIONS: &[&str] = &[
     "-o",

--- a/src/installer/steps/configure/mod.rs
+++ b/src/installer/steps/configure/mod.rs
@@ -1,16 +1,16 @@
-use bootloader::Bootloader;
+use crate::bootloader::Bootloader;
 mod chroot_conf;
 use self::chroot_conf::ChrootConfigurator;
 use super::{mount_cdrom, mount_efivars};
 use crate::installer::{conf::RecoveryEnv, steps::normalize_os_release_name};
-use chroot::Chroot;
-use distribution;
-use errors::*;
-use external::remount_rw;
-use hardware_support;
-use installer::traits::InstallerDiskOps;
+use crate::chroot::Chroot;
+use crate::distribution;
+use crate::errors::*;
+use crate::external::remount_rw;
+use crate::hardware_support;
+use crate::installer::traits::InstallerDiskOps;
 use libc;
-use misc;
+use crate::misc;
 use os_release::OsRelease;
 use partition_identity::PartitionID;
 use rayon;
@@ -21,10 +21,10 @@ use std::{
     path::Path,
 };
 use tempdir::TempDir;
-use timezones::Region;
-use Config;
-use UserAccountCreate;
-use INSTALL_HARDWARE_SUPPORT;
+use crate::timezones::Region;
+use crate::Config;
+use crate::UserAccountCreate;
+use crate::INSTALL_HARDWARE_SUPPORT;
 
 /// Self-explanatory -- the fstab file will be generated with this header.
 const FSTAB_HEADER: &[u8] = b"# /etc/fstab: static file system information.

--- a/src/installer/steps/initialize.rs
+++ b/src/installer/steps/initialize.rs
@@ -1,11 +1,11 @@
-use disks::*;
-use misc;
+use crate::disks::*;
+use crate::misc;
 use rayon;
 use std::{
     io::{self, BufRead},
     path::{Path, PathBuf},
 };
-use Config;
+use crate::Config;
 
 pub fn initialize<F: FnMut(i32)>(
     disks: &mut Disks,

--- a/src/installer/steps/mod.rs
+++ b/src/installer/steps/mod.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use sys_mount::*;
-use NO_EFI_VARIABLES;
+use crate::NO_EFI_VARIABLES;
 
 /// Installation step
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/installer/steps/partition.rs
+++ b/src/installer/steps/partition.rs
@@ -1,6 +1,6 @@
-use disks::{operations::FormatPartitions, Disks};
-use errors::IoContext;
-use external::{blockdev, pvs, vgactivate, vgdeactivate};
+use crate::disks::{operations::FormatPartitions, Disks};
+use crate::errors::IoContext;
+use crate::external::{blockdev, pvs, vgactivate, vgdeactivate};
 use itertools::Itertools;
 use rayon::{self, prelude::*};
 use std::{collections::BTreeMap, io, path::PathBuf, thread::sleep, time::Duration};

--- a/src/installer/traits.rs
+++ b/src/installer/traits.rs
@@ -1,11 +1,11 @@
 use self::FileSystem::*;
 use super::bitflags::FileSystemSupport;
 use disk_types::{BlockDeviceExt, FileSystem, PartitionExt};
-use disks::{Disks};
-use errors::IntoIoResult;
-use external::generate_unique_id;
+use crate::disks::{Disks};
+use crate::errors::IntoIoResult;
+use crate::external::generate_unique_id;
 use fstab_generate::BlockInfo;
-use misc::hasher;
+use crate::misc::hasher;
 use partition_identity::PartitionID;
 use std::{
     borrow::Cow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,11 @@ extern crate rayon;
 extern crate systemd_boot_conf;
 extern crate tempdir;
 
-pub use bootloader::*;
+pub use crate::bootloader::*;
 pub use disk_types::*;
-pub use disks::*;
-pub use misc::device_layout_hash;
-pub use upgrade::*;
+pub use crate::disks::*;
+pub use crate::misc::device_layout_hash;
+pub use crate::upgrade::*;
 
 pub use self::installer::RecoveryEnv;
 
@@ -75,7 +75,7 @@ use std::{
 };
 
 use anyhow::Context;
-use external::dmlist;
+use crate::external::dmlist;
 use partition_identity::PartitionID;
 use sys_mount::*;
 use systemd_boot_conf::SystemdBootConf;
@@ -85,7 +85,7 @@ pub use self::{installer::*, logging::log};
 /// When set to true, this will stop the installation process.
 pub static KILL_SWITCH: AtomicBool = AtomicBool::new(false);
 
-pub use bootloader::FORCE_BOOTLOADER;
+pub use crate::bootloader::FORCE_BOOTLOADER;
 
 /// Exits before the unsquashfs step
 pub static PARTITIONING_TEST: AtomicBool = AtomicBool::new(false);

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,11 +1,11 @@
 use apt_cli_wrappers::AptUpgradeEvent;
-use auto::{InstallOption, InstallOptionError, RecoveryOption};
-use chroot::SystemdNspawn;
+use crate::auto::{InstallOption, InstallOptionError, RecoveryOption};
+use crate::chroot::SystemdNspawn;
 use err_derive::Error;
-use disks::Disks;
-use errors::IoContext;
-use external::remount_rw;
-use installer::{steps::mount_efivars, RecoveryEnv};
+use crate::disks::Disks;
+use crate::errors::IoContext;
+use crate::external::remount_rw;
+use crate::installer::{steps::mount_efivars, RecoveryEnv};
 use std::{io, path::Path, process::Stdio};
 use systemd_boot_conf::SystemdBootConf;
 use tempdir::TempDir;


### PR DESCRIPTION
- Add crate:: prefix to use statements
- Add "edition" to the Cargo.toml files

Partially done with `cargo fix --edition`