### PR TITLE
Dynamically determine switchable graphics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libdbus-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +473,7 @@ dependencies = [
 name = "distinst-hardware-support"
 version = "0.1.0"
 dependencies = [
+ "dbus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "distinst-utils 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "os-release 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1693,6 +1703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum dbus 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
 "checksum dbus 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38f8875bb7afbc20dec12db09e18af3dcbd672b08592d2932950326a6437c616"
+"checksum dbus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22c08adfeb70c940c14d8af988fa854dcb5529e6141f2397e4e0fa4c9375d094"
 "checksum derive-new 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 "checksum derive_more 0.99.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"

--- a/crates/hardware/Cargo.toml
+++ b/crates/hardware/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 distinst-utils = { path = "../utils" }
+dbus = "0.9"
 os-release = "0.1.0"
 proc-modules = "0.1.0"
 raw-cpuid = "7.0.3"


### PR DESCRIPTION
Make check for switchable graphics generic by calling `com.system76.PowerDaemon.GetSwitchable`, which uses PCI enumeration to determine support.

Limit the result to System76 models due to causing problems on other vendor's machines in the past.