### PR TITLE
fix: Use iso-codes package and 'common_name'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -487,12 +487,13 @@ version = "0.1.0"
 dependencies = [
  "distinst-utils 0.1.0",
  "gettext-rs 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "iso3166-1 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "isolang 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-xml-rs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -711,11 +712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iso3166-1"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "isolang"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,7 +894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "once_cell"
-version = "1.3.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1400,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1496,7 +1492,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1730,7 +1726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hostname-validator 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70b8bcb948d9f63a35f0527cde7ca4f4794e817451eaebd47a3c92ef6905c129"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-"checksum iso3166-1 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ece62adcb2a0461fcda598d6de350e0b385dc355ac6ac3984428c8eb973eb9ac"
 "checksum isolang 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "265ef164908329e47e753c769b14cbb27434abf0c41984dca201484022f09ce5"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
@@ -1755,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e521b6adefa0b2c1fa5d2abdf9a5216288686fe6146249215d884c0e5ab320b0"
-"checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+"checksum once_cell 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 "checksum os-detect 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0aea13363b04f639cec843005eef8527671b1cca253f3bcc279b0cbed90c1171"
 "checksum os-release 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
 "checksum partition-identity 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ec13ba9a0eec5c10a89f6ec1b6e9e2ef7d29b810d771355abbd1c43cae003ed6"
@@ -1814,7 +1809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 "checksum serde-xml-rs 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efe415925cf3d0bbb2fc47d09b56ce03eef51c5d56846468a39bcc293c7a846c"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
-"checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+"checksum serde_json 1.0.61 (registry+https://github.com/rust-lang/crates.io-index)" = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum smart-default 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"

--- a/crates/locales/Cargo.toml
+++ b/crates/locales/Cargo.toml
@@ -13,9 +13,10 @@ edition = "2018"
 [dependencies]
 distinst-utils = { path = "../utils/" }
 gettext-rs = "0.4.4"
-iso3166-1 = "1.0.1"
 isolang = "1.0.0"
 lazy_static = "1.4.0"
+once_cell = "1.5.2"
 serde = "1.0.106"
 serde_derive = "1.0.106"
+serde_json = "1.0.61"
 serde-xml-rs = "0.4.0"

--- a/crates/locales/src/iso3166_1.rs
+++ b/crates/locales/src/iso3166_1.rs
@@ -1,0 +1,35 @@
+use once_cell::sync::Lazy;
+use serde_json::from_reader;
+use std::collections::HashMap;
+use std::fs::File;
+
+const JSON_PATH: &str = "/usr/share/iso-codes/json/iso_3166-1.json";
+
+#[derive(Debug, Deserialize)]
+pub struct Country {
+    alpha_2: String,
+    alpha_3: String,
+    name: String,
+    numeric: String,
+    official_name: Option<String>,
+    common_name: Option<String>,
+}
+
+impl Country {
+    pub fn all() -> &'static [Self] {
+        static COUNTRIES: Lazy<Vec<Country>> = Lazy::new(|| {
+            let f = File::open(JSON_PATH).unwrap();
+            let mut m: HashMap<String, Vec<Country>> = from_reader(f).unwrap();
+            m.remove("3166-1").unwrap()
+        });
+        Lazy::force(&COUNTRIES).as_slice()
+    }
+
+    pub fn from_alpha_2(alpha_2: &str) -> Option<&'static Self> {
+        Self::all().iter().find(|i| i.alpha_2 == alpha_2)
+    }
+
+    pub fn common_name(&self) -> &str {
+        self.common_name.as_ref().unwrap_or(&self.name)
+    }
+}

--- a/crates/locales/src/iso_codes.rs
+++ b/crates/locales/src/iso_codes.rs
@@ -1,8 +1,9 @@
 use super::get_default;
 use gettextrs::*;
-use iso3166_1::{alpha2 as iso_3166_1, CountryCode};
 use isolang::Language;
 use std::env;
+
+use crate::iso3166_1::Country;
 
 /// Fetch the ISO 639 name of a language code.
 pub fn get_language_name(code: &str) -> Option<&'static str> {
@@ -33,26 +34,24 @@ pub fn get_language_name_translated(code: &str) -> Option<String> {
 
 /// Get the country name of an ISO 3166 country code.
 pub fn get_country_name(code: &str) -> Option<&'static str> {
-    if code == "TW" || code == "TWN" {
-        Some("Taiwan")
-    } else {
-        iso_3166_1(code).map(|x| x.name)
-    }
+    get_country(code).map(|x| x.common_name())
 }
 
 /// Get a country code from an ISO 3166 country code.
-pub fn get_country(code: &str) -> Option<CountryCode> { iso_3166_1(code) }
+pub fn get_country(code: &str) -> Option<&'static Country> {
+    Country::from_alpha_2(code)
+}
 
 /// Get the country name translated into the given language code.
 pub fn get_country_name_translated(country_code: &str, lang_code: &str) -> Option<String> {
-    get_country_name(country_code).map(|country| {
+    get_country_name(country_code).map(|country_name| {
         let current_lang = env::var("LANGUAGE");
         if let Some(locale) = get_default(lang_code) {
             env::set_var("LANGUAGE", locale);
         }
 
         setlocale(LocaleCategory::LcAll, "");
-        let result = dgettext("iso_3166", country);
+        let result = dgettext("iso_3166", country_name);
 
         match current_lang {
             Ok(lang) => env::set_var("LANGUAGE", lang),

--- a/crates/locales/src/lib.rs
+++ b/crates/locales/src/lib.rs
@@ -3,7 +3,6 @@
 
 extern crate distinst_utils as misc;
 extern crate gettextrs;
-extern crate iso3166_1;
 extern crate isolang;
 #[macro_use]
 extern crate lazy_static;
@@ -12,6 +11,7 @@ extern crate serde_derive;
 extern crate serde_xml_rs;
 
 mod i18n;
+mod iso3166_1;
 mod iso_codes;
 mod keyboard_layout;
 mod main_countries;

--- a/debian/control
+++ b/debian/control
@@ -36,6 +36,7 @@ Depends:
   fatresize,
   gettext,
   grub2-common,
+  iso-codes,
   kpartx,
   kpartx-boot,
   libparted-fs-resize0,


### PR DESCRIPTION
The `iso3166-1` crate seems to be outdated and unmaintained. Debian packages data files with the necessary information, and `distinst` already depends on various Debian packages, so it's probably better to use that.

This fixes https://github.com/pop-os/distinst/issues/240 as well addressing failures to translate where the string from the `iso3166-1` crate was not in the gettext translation data.

This can be tested with `cargo run --example locale` and with `pop-installer`.