### PR TITLE
Support secure boot in non Pop!_OS distributions

### DIFF
--- a/src/installer/steps/bootloader.rs
+++ b/src/installer/steps/bootloader.rs
@@ -133,7 +133,7 @@ pub fn bootloader<F: FnMut(i32)>(
                         let loader = if &name == "Pop!_OS" {
                             "\\EFI\\systemd\\systemd-bootx64.efi".into()
                         } else {
-                            format!("\\EFI\\{}\\grubx64.efi", name)
+                            format!("\\EFI\\{}\\shimx64.efi", name)
                         };
 
                         let args: &[&OsStr] = &[


### PR DESCRIPTION
Systems with secure boot enabled can't load grub directly as it isn't signed with a Microsoft key. They first have to load the shim.