### PR TITLE
Fixes for recent regressions in disk probing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cascade"
@@ -385,6 +385,7 @@ version = "0.1.5"
 dependencies = [
  "err-derive 0.3.0",
  "libparted",
+ "log",
  "os-detect",
  "sys-mount",
  "sysfs-class",
@@ -844,9 +845,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libdbus-sys"
@@ -1016,9 +1017,9 @@ checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10acf907b94fc1b1a152d08ef97e7759650268cf986bf127f387e602b02c7e5a"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "os-detect"
@@ -1422,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -1443,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1497,9 +1498,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/disk-ops/src/mkpart.rs
+++ b/crates/disk-ops/src/mkpart.rs
@@ -1,4 +1,4 @@
-use disk_types::{BlockDeviceExt, FileSystem, PartitionExt, PartitionType};
+use disk_types::{BlockDeviceExt, FileSystem, PartitionExt, PartitionType, SectorExt};
 use libparted::{
     Device, FileSystemType as PedFileSystem, Geometry, Partition as PedPartition, PartitionFlag,
     PartitionType as PedPartitionType,
@@ -49,6 +49,12 @@ impl PartitionExt for PartitionCreate {
     fn get_partition_label(&self) -> Option<&str> { self.label.as_deref() }
 
     fn get_partition_type(&self) -> PartitionType { self.kind }
+}
+
+impl SectorExt for PartitionCreate {
+    fn get_sectors(&self) -> u64 {
+        self.get_sector_end() - self.get_sector_start()
+    }
 }
 
 /// Creates a new partition on the device using the info in the `partition` parameter.

--- a/crates/disk-types/Cargo.toml
+++ b/crates/disk-types/Cargo.toml
@@ -3,9 +3,6 @@ name = "disk-types"
 version = "0.1.5"
 authors = ["Jeremy Soller <jackpot51@gmail.com>", "Michael Aaron Murphy <mmstickman@gmail.com>"]
 description = "Common traits and types for handling block devices, partitions, file systems, etc."
-repository = "https://github.com/pop-os/disk-types"
-readme = "README.md"
-license = "MIT"
 keywords =  ["disk", "partition"]
 categories = ["filesystem", "os"]
 edition = "2018"
@@ -17,3 +14,4 @@ os-detect = { path = "../os-detect" }
 sysfs-class = "0.1.2"
 libparted = "0.1.4"
 err-derive = "0.3"
+log = "0.4"

--- a/crates/disk-types/src/lib.rs
+++ b/crates/disk-types/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate err_derive;
+#[macro_use]
+extern crate log;
 
 mod device;
 mod fs;
@@ -7,5 +9,6 @@ mod partition;
 mod sector;
 mod table;
 mod usage;
+mod utils;
 
 pub use self::{device::*, fs::*, partition::*, sector::*, table::*, usage::*};

--- a/crates/disk-types/src/partition.rs
+++ b/crates/disk-types/src/partition.rs
@@ -1,5 +1,6 @@
 use crate::{
     device::BlockDeviceExt,
+    sector::SectorExt,
     fs::FileSystem::{self, *},
     usage::sectors_used,
 };
@@ -10,7 +11,7 @@ use sys_mount::*;
 use tempdir::TempDir;
 
 /// Trait to provide methods for interacting with partition-based block device.
-pub trait PartitionExt: BlockDeviceExt {
+pub trait PartitionExt: BlockDeviceExt + SectorExt {
     /// Defines the file system that this device was partitioned with.
     fn get_file_system(&self) -> Option<FileSystem>;
 

--- a/crates/disk-types/src/utils.rs
+++ b/crates/disk-types/src/utils.rs
@@ -1,0 +1,14 @@
+use std::fmt::Debug;
+use std::str::FromStr;
+use std::path::Path;
+use std::{io, fs};
+
+pub fn read_file<T: FromStr>(path: &Path) -> io::Result<T>
+where
+    <T as FromStr>::Err: Debug,
+{
+    fs::read_to_string(path)?
+        .trim()
+        .parse::<T>()
+        .map_err(|why| io::Error::new(io::ErrorKind::Other, format!("{:?}", why)))
+}

--- a/crates/disks/src/config/disk.rs
+++ b/crates/disks/src/config/disk.rs
@@ -123,7 +123,11 @@ impl BlockDeviceExt for Disk {
     fn is_read_only(&self) -> bool { self.read_only }
 }
 
-impl SectorExt for Disk {}
+impl SectorExt for Disk {
+    fn get_sectors(&self) -> u64 {
+        self.size
+    }
+}
 
 impl PartitionTableExt for Disk {
     fn get_partition_table(&self) -> Option<PartitionTable> { self.table_type }

--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -7,7 +7,7 @@ use super::{
     partitions::{FORMAT, REMOVE, SOURCE},
     Disk, LvmEncryption, PartitionTable, PVS,
 };
-use disk_types::{BlockDeviceExt, PartitionExt, PartitionTableExt};
+use disk_types::{BlockDeviceExt, PartitionExt, PartitionTableExt, SectorExt};
 use crate::external::{
     cryptsetup_close, cryptsetup_open, lvs, physical_volumes_to_deactivate, pvs, vgdeactivate,
     CloseBy,

--- a/crates/disks/src/config/lvm/mod.rs
+++ b/crates/disks/src/config/lvm/mod.rs
@@ -63,7 +63,11 @@ impl PartitionTableExt for LogicalDevice {
     fn get_partition_type_count(&self) -> (usize, usize, bool) { (0, 0, false) }
 }
 
-impl SectorExt for LogicalDevice { }
+impl SectorExt for LogicalDevice {
+    fn get_sectors(&self) -> u64 {
+        self.sectors
+    }
+}
 
 impl DiskExt for LogicalDevice {
     const LOGICAL: bool = true;

--- a/crates/disks/src/config/lvm/mod.rs
+++ b/crates/disks/src/config/lvm/mod.rs
@@ -101,6 +101,8 @@ impl LogicalDevice {
         let device_path = PathBuf::from(format!("/dev/mapper/{}", volume_group.replace("-", "--")));
         let mounts = MOUNTS.read().expect("unable to get mounts within LogicalDevice::new");
 
+        eprintln!("Logical device of {} is {:?}", volume_group,device_path);
+
         LogicalDevice {
             model_name: ["LVM ", &volume_group].concat(),
             mount_point: mounts.get_mount_by_source(&device_path).map(|m| m.dest.clone()),
@@ -207,6 +209,8 @@ impl LogicalDevice {
                         continue
                     }
                 };
+
+                eprintln!("Found logical device {:?}: {:?}", path, device_path);
 
                 let partition = PartitionInfo {
                     bitflags: SOURCE,

--- a/crates/disks/src/config/partitions/mod.rs
+++ b/crates/disks/src/config/partitions/mod.rs
@@ -5,7 +5,7 @@ use super::{
     super::{LvmEncryption, PartitionError},
     PVS,
 };
-pub use disk_types::{BlockDeviceExt, FileSystem, PartitionExt, PartitionType};
+pub use disk_types::{BlockDeviceExt, FileSystem, PartitionExt, PartitionType, SectorExt};
 use crate::external::{get_label, is_encrypted};
 use fstab_generate::BlockInfo;
 use libparted::{Partition, PartitionFlag};
@@ -103,6 +103,12 @@ impl PartitionExt for PartitionInfo {
     fn get_sector_end(&self) -> u64 { self.end_sector }
 
     fn get_sector_start(&self) -> u64 { self.start_sector }
+}
+
+impl SectorExt for PartitionInfo {
+    fn get_sectors(&self) -> u64 {
+        self.get_sector_end() - self.get_sector_start()
+    }
 }
 
 impl PartitionInfo {

--- a/crates/external/src/lvm.rs
+++ b/crates/external/src/lvm.rs
@@ -228,6 +228,7 @@ pub fn pvs() -> io::Result<BTreeMap<PathBuf, Option<String>>> {
             let mut fields = current_line[2..].split_whitespace();
             fields.next().map(|pv| {
                 fields.next().map(|vg| {
+                    eprintln!("Found PV {}: VG {}", pv, vg);
                     output.insert(
                         PathBuf::from(pv),
                         if vg.is_empty() || vg == "lvm2" { None } else { Some(vg.into()) },

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -97,6 +97,8 @@ impl InstallOptions {
                 if device.is_read_only() || device.contains_mount("/", &disks) {
                     continue;
                 }
+                
+                eprintln!("device: {:?}", device.get_device_path());
 
                 let mut last_end_sector = 1024;
 

--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -346,7 +346,7 @@ impl<'a> ChrootConfigurator<'a> {
             self.chroot
                 .command(
                     "rsync",
-                    &["-KLavc", "/cdrom/.disk", "/cdrom/dists", "/cdrom/pool", "/recovery"],
+                    &["-KLavc", "--delete-before", "/cdrom/.disk", "/cdrom/dists", "/cdrom/pool", "/recovery"],
                 )
                 .run()?;
 


### PR DESCRIPTION
- Fix a panic caused by code not getting the correct path for the parent of a partition block device
- Fixed another panic caused by the probing the contents of CD ROM, which should never be an install target