### PR TITLE
feat: Use ubuntu-drivers to find drivers and install

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -213,6 +213,11 @@ fn main() {
                 .takes_value(true)
                 .multiple(true),
         )
+        .arg(
+            Arg::with_name("run-ubuntu-drivers")
+                .long("run-ubuntu-drivers")
+                .help("use ubuntu-drivers to find drivers then install in the chroot, some may have proprietary licenses")
+        )
         .get_matches();
 
     if let Err(err) = distinst::log(|_level, _message| {}) {
@@ -405,6 +410,12 @@ fn install_flags(matches: &ArgMatches) -> u8 {
 
     flags += if matches.occurrences_of("hardware-support") != 0 {
         distinst::INSTALL_HARDWARE_SUPPORT
+    } else {
+        0
+    };
+
+    flags += if matches.occurrences_of("run-ubuntu-drivers") != 0 {
+        distinst::RUN_UBUNTU_DRIVERS
     } else {
         0
     };

--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -25,6 +25,7 @@ namespace Distinst {
     public const uint8 MODIFY_BOOT_ORDER;
     public const uint8 INSTALL_HARDWARE_SUPPORT;
     public const uint8 KEEP_OLD_ROOT;
+    public const uint8 RUN_UBUNTU_DRIVERS;
 
     [CCode (has_type_id = false, destroy_function = "")]
     public struct Config {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -21,6 +21,7 @@ pub use self::{
 pub const DISTINST_MODIFY_BOOT_ORDER: u8 = 0b1;
 pub const DISTINST_INSTALL_HARDWARE_SUPPORT: u8 = 0b10;
 pub const DISTINST_KEEP_OLD_ROOT: u8 = 0b100;
+pub const DISTINST_RUN_UBUNTU_DRIVERS: u8 = 0b1000;
 
 use std::io;
 

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -34,6 +34,7 @@ use crate::PARTITIONING_TEST;
 pub const MODIFY_BOOT_ORDER: u8 = 0b01;
 pub const INSTALL_HARDWARE_SUPPORT: u8 = 0b10;
 pub const KEEP_OLD_ROOT: u8 = 0b100;
+pub const RUN_UBUNTU_DRIVERS: u8 = 0b1000;
 
 macro_rules! percent {
     ($steps:expr) => {

--- a/src/installer/steps/configure/mod.rs
+++ b/src/installer/steps/configure/mod.rs
@@ -25,6 +25,7 @@ use crate::timezones::Region;
 use crate::Config;
 use crate::UserAccountCreate;
 use crate::INSTALL_HARDWARE_SUPPORT;
+use crate::RUN_UBUNTU_DRIVERS;
 
 /// Self-explanatory -- the fstab file will be generated with this header.
 const FSTAB_HEADER: &[u8] = b"# /etc/fstab: static file system information.
@@ -270,6 +271,7 @@ pub fn configure<D: InstallerDiskOps, P: AsRef<Path>, S: AsRef<str>, F: FnMut(i3
         let apt_install = chroot
             .cdrom_add()
             .and_then(|_| chroot.apt_install(&install_pkgs))
+            .and_then(|_| chroot.install_drivers(config.flags & RUN_UBUNTU_DRIVERS != 0))
             .and_then(|_| chroot.cdrom_disable());
 
         map_errors! {


### PR DESCRIPTION
Fixes #228 

This probably isn't great code; I'm only very beginner level with Rust. Feel free to refactor at will.

I've tested that this works with the `distinst` CLI. Passing the new `--run-ubuntu-drivers` option allows it to install the proprietary `bcmwl-kernel-source` driver for my WiFi chipset from the apt-cdrom repository on an elementary iso when it normally wouldn't.