### PR TITLE
fix(user-create): Set default shell as /bin/bash

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -169,7 +169,7 @@ impl<'a> ChrootConfigurator<'a> {
         fullname: Option<&str>,
         profile_icon: &str,
     ) -> io::Result<()> {
-        let mut command = self.chroot.command("useradd", &["-m", "-G", "adm,sudo"]);
+        let mut command = self.chroot.command("useradd", &["-m", "-G", "adm,sudo,lpadmin", "-s", "/bin/bash"]);
         if let Some(name) = fullname {
             command.args(&["-c", name, user]);
         } else {


### PR DESCRIPTION
Because `useradd` defaults the shell to `/bin/sh` in `/etc/default/useradd`.

Required by https://github.com/pop-os/installer/pull/219