### PR TITLE
fix(chroot): Only read buffer at char boundaries

### DIFF
--- a/crates/chroot/src/command.rs
+++ b/crates/chroot/src/command.rs
@@ -168,8 +168,10 @@ fn non_blocking_line_reading<B: BufRead, F: Fn(&str)>(
         match reader.read_line(buffer) {
             Ok(0) => break,
             Ok(read) => {
-                callback(&buffer[..read - 1]);
-                buffer.clear();
+                if buffer.is_char_boundary(read) {
+                    callback(&buffer[..read - 1]);
+                    buffer.clear();
+                }
             }
             Err(ref why) if why.kind() == io::ErrorKind::WouldBlock => break,
             Err(why) => {


### PR DESCRIPTION
Fixes https://github.com/pop-os/pop/issues/1939. May also fix https://github.com/pop-os/iso/issues/256 based on its description, although I could not recreate that one.

When attempting to install with certain languages, distinst was crashing while running an apt command in the chroot:

<details><summary>Crash output:</summary>
<p>

```
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.271d6JpjwvUr" "apt-get" "install" "-q" "-y" "-o" "Acquire::cdrom::AutoDetect=0" "-o" "Acquire::cdrom::mount=/cdrom" "-o" "APT::CDROM::NoMount=1" "kernelstub" "system76-driver" "e2fsprogs" "dosfstools" "cryptsetup" "cryptsetup-bin" "lvm2" "dmeventd" "dmraid" "kpartx" "kpartx-boot"
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:156] disabling apt-cdrom from /etc/apt/sources.list
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:57] removing packages: ["btrfs-progs", "casper", "cifs-utils", "distinst", "expect", "f2fs-tools", "fatresize", "gettext", "gparted", "gparted-common", "grub-common", "grub2-common", "libdistinst", "libdmraid1.0.0.rc16", "libinih1", "libnss-mymachines", "localechooser-data", "os-prober", "pop-installer", "pop-installer-casper", "pop-shop-casper", "squashfs-tools", "systemd-container", "tcl-expect", "user-setup", "xfsprogs"]
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.271d6JpjwvUr" "apt-get" "purge" "-y" "btrfs-progs" "casper" "cifs-utils" "distinst" "expect" "f2fs-tools" "fatresize" "gettext" "gparted" "gparted-common" "grub-common" "grub2-common" "libdistinst" "libdmraid1.0.0.rc16" "libinih1" "libnss-mymachines" "localechooser-data" "os-prober" "pop-installer" "pop-installer-casper" "pop-shop-casper" "squashfs-tools" "systemd-container" "tcl-expect" "user-setup" "xfsprogs"
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] Načítají se stavové informace…
[INFO distinst:crates/chroot/src/command.rs:98] Následující balíky budou ODSTRANĚNY:
[INFO distinst:crates/chroot/src/command.rs:98]   btrfs-progs* casper* cifs-utils* distinst* dmraid* expect* f2fs-tools*
[INFO distinst:crates/chroot/src/command.rs:98]   fatresize* gettext* gparted* gparted-common* grub-common* grub2-common*
[INFO distinst:crates/chroot/src/command.rs:98]   libdistinst* libdmraid1.0.0.rc16* libinih1* libnss-mymachines*
[INFO distinst:crates/chroot/src/command.rs:98]   localechooser-data* os-prober* pop-installer* pop-installer-casper*
[INFO distinst:crates/chroot/src/command.rs:98]   pop-shop-casper* squashfs-tools* systemd-container* tcl-expect* user-setup*
[INFO distinst:crates/chroot/src/command.rs:98]   xfsprogs*
[INFO distinst:crates/chroot/src/command.rs:98] 0 aktualizováno, 0 nově instalováno, 27 k odstranění a 0 neaktualizováno.
                                         [INFO distinst:crates/chroot/src/command.rs:98] Po této operaci bude na disku uvolněno 46,5 MB.
                                                        thread '<unnamed>' panicked at 'byte index 149 is not a char boundary; it is inside '…' (bytes 148..151)(Na`[...]', crates/chroot/src/command.rs:171:27
                                               note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
                                            fatal runtime error: failed to initiate panic, error 5
                  Aborted (core dumped)
```
</p>
</details>

Investigating that error message, I found [information](https://stackoverflow.com/questions/51982999/slice-a-string-containing-unicode-chars) about why this slice operation wasn't working, and then found a [suggestion](https://www.reddit.com/r/rust/comments/765n76/psa_caution_with_slicing_strings/dobp9gv/) to use the [is_char_boundary method](https://doc.rust-lang.org/std/primitive.str.html#method.is_char_boundary) to search for a character boundary.

From how I read this code, it's iterating through a buffer and continuously reading/running a callback/clearing the buffer. This was crashing when the point being read was not at a char boundary. The intention of this change is to only perform the read/callback/clear operations at points in the buffer that are character boundaries. (This should not affect any languages that were already working because the lack of a crash meant that these operations were already running only at points that were not character boundaries.)

The working output with this fix, particularly around where distinst was crashing before, doesn't look cut off compared to the working English output before the fix:

<details><summary>Working Czech output (with fix):</summary>
<p>

```
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.pvPKIo8meazE" "apt-get" "install" "-q" "-y" "-o" "Acquire::cdrom::AutoDetect=0" "-o" "Acquire::cdrom::mount=/cdrom" "-o" "APT::CDROM::NoMount=1" "kernelstub" "system76-driver" "e2fsprogs" "dosfstools" "cryptsetup" "cryptsetup-bin" "lvm2" "dmeventd" "dmraid" "kpartx" "kpartx-boot"
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:156] disabling apt-cdrom from /etc/apt/sources.list
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:57] removing packages: ["btrfs-progs", "casper", "cifs-utils", "distinst", "expect", "f2fs-tools", "fatresize", "gettext", "gparted", "gparted-common", "grub-common", "grub2-common", "libdistinst", "libdmraid1.0.0.rc16", "libinih1", "libnss-mymachines", "localechooser-data", "os-prober", "pop-installer", "pop-installer-casper", "pop-shop-casper", "squashfs-tools", "systemd-container", "tcl-expect", "user-setup", "xfsprogs"]
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.pvPKIo8meazE" "apt-get" "purge" "-y" "btrfs-progs" "casper" "cifs-utils" "distinst" "expect" "f2fs-tools" "fatresize" "gettext" "gparted" "gparted-common" "grub-common" "grub2-common" "libdistinst" "libdmraid1.0.0.rc16" "libinih1" "libnss-mymachines" "localechooser-data" "os-prober" "pop-installer" "pop-installer-casper" "pop-shop-casper" "squashfs-tools" "systemd-container" "tcl-expect" "user-setup" "xfsprogs"
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] Načítají se stavové informace…
[INFO distinst:crates/chroot/src/command.rs:98] Následující balíky budou ODSTRANĚNY:
[INFO distinst:crates/chroot/src/command.rs:98]   btrfs-progs* casper* cifs-utils* distinst* dmraid* expect* f2fs-tools*
[INFO distinst:crates/chroot/src/command.rs:98]   fatresize* gettext* gparted* gparted-common* grub-common* grub2-common*
[INFO distinst:crates/chroot/src/command.rs:98]   libdistinst* libdmraid1.0.0.rc16* libinih1* libnss-mymachines*
[INFO distinst:crates/chroot/src/command.rs:98]   localechooser-data* os-prober* pop-installer* pop-installer-casper*
[INFO distinst:crates/chroot/src/command.rs:98]   pop-shop-casper* squashfs-tools* systemd-container* tcl-expect* user-setup*
[INFO distinst:crates/chroot/src/command.rs:98]   xfsprogs*
[INFO distinst:crates/chroot/src/command.rs:98] 0 aktualizováno, 0 nově instalováno, 27 k odstranění a 0 neaktualizováno.
                                         [INFO distinst:crates/chroot/src/command.rs:98] Po této operaci bude na disku uvolněno 46,5 MB.
                                                        [INFO distinst:crates/ch(Načítá se databáze … 5%(Načítá se databáze … 
        [INFO distinst:crates/chroot/src/command.rs:98] Odstraňuje se balík btrfs-progs (5.10.1-1build1) …
[INFO distinst:crates/chroot/src/command.rs:98] Odstraňuje se balík pop-shop-casper (3.4.2pop0~1625253683~21.04~eff4ef8) …
[INFO distinst:crates/chroot/src/command.rs:98] Odstraňuje se balík pop-installer-casper (0.0.1~1625837472~21.04~d70babe) …
[INFO distinst:crates/chroot/src/command.rs:98] Odstraňuje se balík casper (1.461) …
```
</p>
</details>

<details><summary>Working English output (without fix):</summary>
<p>

```
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.o88GKSSqyEbC" "apt-get" "install" "-q" "-y" "-o" "Acquire::cdrom::AutoDetect=0" "-o" "Acquire::cdrom::mount=/cdrom" "-o" "APT::CDROM::NoMount=1" "kernelstub" "system76-driver" "e2fsprogs" "dosfstools" "cryptsetup" "cryptsetup-bin" "lvm2" "dmeventd" "dmraid" "kpartx" "kpartx-boot"
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:156] disabling apt-cdrom from /etc/apt/sources.list
[INFO distinst:src/installer/steps/configure/chroot_conf.rs:57] removing packages: ["btrfs-progs", "casper", "cifs-utils", "distinst", "expect", "f2fs-tools", "fatresize", "gettext", "gparted", "gparted-common", "grub-common", "grub2-common", "libdistinst", "libdmraid1.0.0.rc16", "libinih1", "libnss-mymachines", "localechooser-data", "os-prober", "pop-installer", "pop-installer-casper", "pop-shop-casper", "squashfs-tools", "systemd-container", "tcl-expect", "user-setup", "xfsprogs"]
[INFO distinst:crates/chroot/src/command.rs:108] running "chroot" "/tmp/distinst.o88GKSSqyEbC" "apt-get" "purge" "-y" "btrfs-progs" "casper" "cifs-utils" "distinst" "expect" "f2fs-tools" "fatresize" "gettext" "gparted" "gparted-common" "grub-common" "grub2-common" "libdistinst" "libdmraid1.0.0.rc16" "libinih1" "libnss-mymachines" "localechooser-data" "os-prober" "pop-installer" "pop-installer-casper" "pop-shop-casper" "squashfs-tools" "systemd-container" "tcl-expect" "user-setup" "xfsprogs"
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] 
[INFO distinst:crates/chroot/src/command.rs:98] Reading state information...
[INFO distinst:crates/chroot/src/command.rs:98] The following packages will be REMOVED:
[INFO distinst:crates/chroot/src/command.rs:98]   btrfs-progs* casper* cifs-utils* distinst* dmraid* expect* f2fs-tools*
[INFO distinst:crates/chroot/src/command.rs:98]   fatresize* gettext* gparted* gparted-common* grub-common* grub2-common*
[INFO distinst:crates/chroot/src/command.rs:98]   libdistinst* libdmraid1.0.0.rc16* libinih1* libnss-mymachines*
[INFO distinst:crates/chroot/src/command.rs:98]   localechooser-data* os-prober* pop-installer* pop-installer-casper*
[INFO distinst:crates/chroot/src/command.rs:98]   pop-shop-casper* squashfs-tools* systemd-container* tcl-expect* user-setup*
[INFO distinst:crates/chroot/src/command.rs:98]   xfsprogs*
[INFO distinst:crates/chroot/src/command.rs:98] 0 upgraded, 0 newly installed, 27 to remove and 0 not upgraded.
                               [INFO distinst:crates/chroot/src/command.rs:98] After this operation, 46.5 MB disk space will be freed.
                                                      [INFO distinst:crates/chro(Reading database ... 20%ading database ... 
[INFO distinst:crates/chroot/src/command.rs:98] Removing distinst (0.3.2~1623858875~21.04~c712fda) ...
[INFO distinst:crates/chroot/src/command.rs:98] Removing libdistinst (0.3.2~1623858875~21.04~c712fda) ...
[INFO distinst:crates/chroot/src/command.rs:98] Removing btrfs-progs (5.10.1-1build1) ...
[INFO distinst:crates/chroot/src/command.rs:98] Removing pop-shop-casper (3.4.2pop0~1625253683~21.04~eff4ef8) ...
[INFO distinst:crates/chroot/src/command.rs:98] Removing pop-installer-casper (0.0.1~1625837472~21.04~d70babe) ...
[INFO distinst:crates/chroot/src/command.rs:98] Removing casper (1.461) ...

```
</p>
</details>