### PR TITLE
Activate casefolding feature by default (without chattr)

### DIFF
--- a/crates/external/src/block.rs
+++ b/crates/external/src/block.rs
@@ -70,7 +70,7 @@ pub fn mkfs<P: AsRef<Path>>(part: P, kind: FileSystem) -> io::Result<()> {
         Exfat => unimplemented!("exfat is not supported, yet"),
         Ext2 => ("mkfs.ext2", &["-F", "-q"]),
         Ext3 => ("mkfs.ext3", &["-F", "-q"]),
-        Ext4 => ("mkfs.ext4", &["-F", "-q", "-E", "lazy_itable_init"]),
+        Ext4 => ("mkfs.ext4", &["-F", "-q", "-E", "lazy_itable_init", "-O", "casefold"]),
         F2fs => ("mkfs.f2fs", &["-q"]),
         Fat16 => ("mkfs.fat", &["-F", "16"]),
         Fat32 => ("mkfs.fat", &["-F", "32"]),


### PR DESCRIPTION
Case-insensitive `ext4` is extremely recent, but the systems this installer's version would be installing are likely to support casefolding.

This feature is useful in cases where a program may not be native to Linux (e.g. being run under WINE [or a derivative], or using a shared codebase between platforms that may not take in/sensitivity in account) and the original implementation of the program assumes case insensitivity. In addition to enabling the casefolding feature at the filesystem level, enabling case insensitivity requires the user (or automated systems) to add the `CI_dir` attribute to a folder. 

Therefore, there is limited to no risk that this feature would apply system-wide from the get-go, unless the installer was to `chattr +F /` before bootstrapping the system drive.

[Short version: enable casefolding by default for easier servicing of Gaming use-cases w.r.t. Proton and other filesystem issues]

References:
* [Using the Linux kernel's Case-insensitive feature in Ext4](https://www.collabora.com/news-and-blog/blog/2020/08/27/using-the-linux-kernel-case-insensitive-feature-in-ext4/) via Collabora