### PR TITLE
debian: Drop grub-efi dependency for elementary

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -115,7 +115,6 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> &'static [&'static str
             "linux-image-generic-hwe-20.04",
         ],
         Bootloader::Efi if os_release.name == "elementary OS" => &[
-            "grub-efi",
             "grub-efi-amd64",
             "grub-efi-amd64-signed",
             "shim-signed",


### PR DESCRIPTION
We've started building Ubuntu 22.04 based images and `grub-efi` no longer exists in Ubuntu `jammy`. It was always just a dummy package that pulled in `grub-efi-amd64` anyway. Dropping this here will stop installation failures due to that package not existing.