### PR TITLE
chore(vapi): Fix compilation with Vala 0.54

### DIFF
--- a/ffi/distinst.vapi
+++ b/ffi/distinst.vapi
@@ -670,7 +670,6 @@ namespace Distinst {
         PERCENT
     }
 
-    [SimpleType]
     [CCode (has_type_id = false)]
     public struct SectorResult {
         /**


### PR DESCRIPTION
Using Vala 0.54 with this vapi file results in the following error:
```
distinst.vapi:683.9-683.27: error: [SimpleType] struct `Distinst.SectorResult' cannot have owned heap-allocated fields
        public string error;
```

`SimpleType` should only be used for stack allocated structures, usually just when a builtin type gets typedef'ed to something in C. Since distinst doesn't manage the lifetime of this structure, we can remove the `SimpleType` and let Vala generate a destroy function for it to clean up the strings left on the heap.

As far as I can tell, this structure or the `from_str` method that returns it isn't used in either the elementary or Pop!_OS version of the installer, so the chance of regressions here should be low.