### PR TITLE
feat: Disable update-initramfs until the installer is ready for it

### DIFF
--- a/src/installer/steps/bootloader.rs
+++ b/src/installer/steps/bootloader.rs
@@ -124,9 +124,9 @@ pub fn bootloader<F: FnMut(i32)>(
                                 &["-o", &format!("/boot/efi/EFI/{}/grub/grub.cfg", name)],
                             )
                             .run()?;
-
-                        chroot.command("update-initramfs", &["-c", "-k", "all"]).run()?;
                     }
+
+                    chroot.command("update-initramfs", &["-c", "-k", "all"]).run()?;
 
                     if config.flags & MODIFY_BOOT_ORDER != 0 {
                         let efi_part_num = efi_part_num.to_string();

--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -266,7 +266,7 @@ impl<'a> ChrootConfigurator<'a> {
     pub fn initramfs_disable(&self) -> io::Result<()> {
         info!("symlinking update-initramfs to true for duration of initial setup");
 
-        self.chroot.command("sh", &"-c", ["mv /usr/sbin/update-initramfs /usr/sbin/update-initramfs.bak"])
+        self.chroot.command("sh", &["-c", "mv /usr/sbin/update-initramfs /usr/sbin/update-initramfs.bak"])
             .run()
             .with_context(|err| format!("failed to migrate `update-initramfs`: {}", err))?;
 

--- a/src/installer/steps/configure/mod.rs
+++ b/src/installer/steps/configure/mod.rs
@@ -245,6 +245,8 @@ pub fn configure<D: InstallerDiskOps, P: AsRef<Path>, S: AsRef<str>, F: FnMut(i3
         // TODO: use a macro to make this more manageable.
         let chroot = ChrootConfigurator::new(chroot);
 
+        chroot.initramfs_disable()?;
+
         let hostname = chroot.hostname(&config.hostname);
         let hosts = chroot.hosts(&config.hostname);
         let machine_id = chroot.generate_machine_id();
@@ -317,9 +319,8 @@ pub fn configure<D: InstallerDiskOps, P: AsRef<Path>, S: AsRef<str>, F: FnMut(i3
             .with_context(|why| format!("error setting keyboard layout: {}", why))?;
         callback(85);
 
-        chroot
-            .update_initramfs()
-            .with_context(|why| format!("error updating initramfs: {}", why))?;
+        chroot.initramfs_reenable()?;
+
         callback(90);
 
         // Sync to the disk before unmounting


### PR DESCRIPTION
This will symlink `/usr/sbin/update-initramfs` to `/usr/bin/true` while the system is being configured, until the final stage wher update-initramfs is manually called for at the end of the bootloader installation.

Fixes #282 