### PR TITLE
Non-x86 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "libc",
  "log",
  "sys-mount",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1277,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "9.0.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
+checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
 dependencies = [
  "bitflags",
 ]
@@ -1655,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/crates/hardware/Cargo.toml
+++ b/crates/hardware/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "distinst-hardware-support"
 version = "0.1.0"
-authors = ["Jeremy Soller <jackpot51@gmail.com>", "Michael Aaron Murphy <mmstickman@gmail.com>"]
+authors = [
+	"Jeremy Soller <jackpot51@gmail.com>",
+	"Michael Aaron Murphy <mmstickman@gmail.com>",
+]
 description = "Linux hardware detection and package recommendation"
 repository = "https://github.com/pop-os/distinst"
 readme = "README.md"
@@ -15,5 +18,7 @@ distinst-utils = { path = "../utils" }
 dbus = "0.9"
 os-release = "0.1.0"
 proc-modules = "0.1.0"
-raw-cpuid = "9.0"
 log = "0.4.8"
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+raw-cpuid = "9.0"

--- a/crates/hardware/src/lib.rs
+++ b/crates/hardware/src/lib.rs
@@ -3,9 +3,11 @@ extern crate distinst_utils as misc;
 extern crate log;
 extern crate os_release;
 extern crate proc_modules;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 extern crate raw_cpuid;
 
 use os_release::OsRelease;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use raw_cpuid::CpuId;
 use std::io::Read;
 
@@ -16,7 +18,7 @@ mod macros;
 use proc_modules::Module;
 
 // NOTE: Distributions should provide their distro ID and associated packages here, if applicable.
-
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn amd_microcode(os_release: &OsRelease) -> Option<&'static str> {
     if &os_release.id_like == "debian" {
         Some("amd64-microcode")
@@ -25,6 +27,7 @@ fn amd_microcode(os_release: &OsRelease) -> Option<&'static str> {
     }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn intel_microcode(os_release: &OsRelease) -> Option<&'static str> {
     if &os_release.id_like == "debian" {
         Some("intel-microcode")
@@ -68,6 +71,7 @@ fn graphics_support(os_release: &OsRelease) -> Option<&'static str> {
 }
 
 /// Microcode packages for specific processor vendors.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn processor_support(os_release: &OsRelease) -> Option<&'static str> {
     if let Some(vf) = CpuId::new().get_vendor_info() {
         return match vf.as_string() {
@@ -77,6 +81,11 @@ fn processor_support(os_release: &OsRelease) -> Option<&'static str> {
         };
     }
 
+    None
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn processor_support(_os_release: &OsRelease) -> Option<&'static str> {
     None
 }
 

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Standards-Version: 4.1.1
 Homepage: https://github.com/pop-os/distinst
 
 Package: distinst
-Architecture: amd64
+Architecture: linux-any
 Depends:
   libdistinst (= ${binary:Version}),
   ${misc:Depends},
@@ -22,7 +22,7 @@ Depends:
 Description: Distribution Installer CLI
 
 Package: libdistinst
-Architecture: amd64
+Architecture: linux-any
 Depends:
   apt,
   btrfs-progs,
@@ -55,7 +55,7 @@ Depends:
 Description: Distribution Installer Library
 
 Package: libdistinst-dev
-Architecture: amd64
+Architecture: linux-any
 Depends:
   libdistinst (= ${binary:Version}),
   ${misc:Depends}


### PR DESCRIPTION
This adds support for building distinst for non-x86(_64) targets, mainly arm64.

Builds fine for me.