### PR TITLE
f2fs: change preferred options

### DIFF
--- a/crates/disks/src/config/partitions/mod.rs
+++ b/crates/disks/src/config/partitions/mod.rs
@@ -24,6 +24,7 @@ pub fn get_preferred_options(fs: FileSystem) -> &'static str {
         FileSystem::Fat16 | FileSystem::Fat32 => "umask=0077",
         FileSystem::Ext4 => "noatime,errors=remount-ro",
         FileSystem::Swap => "sw",
+        FileSystem::F2fs => "defaults,compress_algorithm=lz4,compress_chksum,atgc,gc_merge,lazytime,nodiscard",
         _ => "defaults",
     }
 }

--- a/crates/external/src/block.rs
+++ b/crates/external/src/block.rs
@@ -71,7 +71,7 @@ pub fn mkfs<P: AsRef<Path>>(part: P, kind: FileSystem) -> io::Result<()> {
         Ext2 => ("mkfs.ext2", &["-F", "-q"]),
         Ext3 => ("mkfs.ext3", &["-F", "-q"]),
         Ext4 => ("mkfs.ext4", &["-F", "-q", "-E", "lazy_itable_init"]),
-        F2fs => ("mkfs.f2fs", &["-q"]),
+        F2fs => ("mkfs.f2fs", &["-q", "-O", "extra_attr,inode_checksum,sb_checksum,compression"]),
         Fat16 => ("mkfs.fat", &["-F", "16"]),
         Fat32 => ("mkfs.fat", &["-F", "32"]),
         Ntfs => ("mkfs.ntfs", &["-FQ", "-q"]),


### PR DESCRIPTION
This PR changes preferred options for f2fs.

This set of options was inspired by ArchLinux's [recommended options](https://wiki.archlinux.org/title/F2FS#Recommended_mount_options) with some changes.

### Rationale for some of the options:

- **compress_algorithm=lz4** - compression by itself is useful to prolong flash drive life. The trouble I had was to figure out what algorithm to use for desktop usage. There are several options, generally (from what I managed to find) people tend to use either [zstd](https://github.com/facebook/zstd) or [lz4](https://github.com/lz4/lz4) for filesystem compression.
Judging by [this benchmark](https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf) lz4 is faster at (de)compression but has a lower compression ratio. My thinking here is that this will be less noticeable for end user when reading/writing files. Note that arch linux recommends zstd with compression level 6, I do not insist on using lz4, and I can change it for something else if a compelling argument is provided.
- **nodiscard** - periodic trim is enabled on ubuntu [since 18.04](https://askubuntu.com/a/1034176) (and by extension on pop!_os?). This options disables continuous trim.
Other options are just tweaks to garbage collection, more info about them [here](https://www.kernel.org/doc/html/latest/filesystems/f2fs.html#mount-options) and reducing writes for file access times.

Some of the features of `f2fs` must be enabled at `mkfs` time so that the driver could use the options above. More about this features can be found in [man pages](http://manpages.ubuntu.com/manpages/jammy/man8/mkfs.f2fs.8.html).

