### PR TITLE
Schedule fsck on root partition

### DIFF
--- a/crates/fstab-generate/src/block.rs
+++ b/crates/fstab-generate/src/block.rs
@@ -23,6 +23,7 @@ impl<'a> BlockInfo<'a> {
         target: Option<&Path>,
         options: &'a str,
     ) -> Self {
+        let pass = target == Some(Path::new("/"));
         BlockInfo {
             uid,
             mount: if fs == FileSystem::Swap {
@@ -37,7 +38,7 @@ impl<'a> BlockInfo<'a> {
             },
             options,
             dump: false,
-            pass: false,
+            pass,
         }
     }
 
@@ -110,7 +111,7 @@ mod tests {
             *fstab,
             OsString::from(r#"UUID=SWAP  none  swap  sw  0  0
 PARTUUID=EFI  /boot/efi  vfat  defaults  0  0
-UUID=ROOT  /  ext4  defaults  0  0
+UUID=ROOT  /  ext4  defaults  0  1
 "#)
         );
     }
@@ -181,7 +182,7 @@ UUID=ROOT  /  ext4  defaults  0  0
                 fs: FileSystem::Ext4.into(),
                 options: "defaults",
                 dump: false,
-                pass: false,
+                pass: true,
             }
         );
         assert_eq!(root.mount(), OsStr::new("/"));


### PR DESCRIPTION
Issue: https://github.com/pop-os/distinst/issues/312

Following Ubuntu, Arch, and general best practices for generating fstab entries the root partition should be set to fsck with highest priority. This pull request will set the root partition fsck entry to 1. 

Here's some documentation around fstab values
https://help.ubuntu.com/community/Fstab
https://wiki.archlinux.org/title/fstab

I feel there's some room here for supporting customization and I would be happy to expand on this, but this will be a good starting point to address users concerns