### PR TITLE
Don't hard fail on failed driver installation

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -142,7 +142,15 @@ impl<'a> ChrootConfigurator<'a> {
                 },
             );
 
-            command.run()
+            let result = command.run();
+            match result {
+                Ok(()) => Ok(()),
+                // Don't fail the whole install if it wasn't possible to install drivers
+                Err(_) => {
+                    warn!("Unable to install optional drivers");
+                    Ok(())
+                }
+            }
         } else {
             Ok(())
         }


### PR DESCRIPTION
This feature was added by me in #255 but it is desirable that we don't fail the whole installation process if an optional driver fails to install.