### PR TITLE
Only install --recommended drivers

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -121,7 +121,7 @@ impl<'a> ChrootConfigurator<'a> {
         let mut packages = Vec::new();
         if install {
             info!("finding drivers for hardware");
-            let args: &[&str] = &["list"];
+            let args: &[&str] = &["list", "--recommended"];
             let output = self.chroot.command("ubuntu-drivers", args).run_with_stdout()?;
 
             for result in output.lines().map(|line| line.split(",").nth(0)) {


### PR DESCRIPTION
Coming from here https://github.com/elementary/os/issues/686#issuecomment-1697587704

`ubuntu-drivers list` returns a list of 9 Nvidia drivers in Ubuntu 22.04 and elementary OS 7. However, we only want to install one of them. With `--recommended`, only the most recent driver will be listed.

Committed from the GitHub web UI, I don't have a development environment for this right now.