### PR TITLE
Fix parsing of "ubuntu-drivers list --recommended" output

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -124,7 +124,7 @@ impl<'a> ChrootConfigurator<'a> {
             let output = self.chroot.command("ubuntu-drivers", args).run_with_stdout()?;
             // ubuntu-drivers returns packages separated by newlines and/or space characters.
             // https://git.launchpad.net/ubuntu/+source/ubuntu-drivers-common/tree/ubuntu-drivers#n479
-            let packages: Vec<&str> = output.lines().flat_map(|line| line.split(" ")).collect();
+            let packages: Vec<&str> = output.lines().flat_map(|line| line.trim().split(" ")).collect();
 
             info!("installing drivers: {:?}", packages);
             let mut command = self.chroot.command(


### PR DESCRIPTION
Follow-up to #320, based on discussion here https://github.com/elementary/os/issues/686#issuecomment-1710730849

"ubuntu-drivers" uses different separators when passing the "--recommended" flag, so the current `split(",")` breaks when more than one package name is being returned. This PR adjusts the code so that multi-package and multi-line output can both be parsed correctly.
