### PR TITLE
fix: Stop populating hostname in /etc/hosts by default

### DIFF
--- a/src/installer/steps/configure/chroot_conf.rs
+++ b/src/installer/steps/configure/chroot_conf.rs
@@ -256,10 +256,10 @@ impl<'a> ChrootConfigurator<'a> {
         let mut file = misc::create(&hosts)?;
         writeln!(
             &mut file,
-            r#"127.0.0.1	localhost
-::1		localhost
-127.0.1.1	{0}.localdomain	{0}"#,
-            hostname
+            "# See `man hosts` for details.\n#
+# By default, systemd-resolved or libnss-myhostname will resolve
+# localhost and the system hostname if they're not specified here.
+127.0.0.1\tlocalhost\n::1\t\tlocalhost"
         )
         .with_context(|err| format!("failed to write hosts to {:?}: {}", hosts, err))
     }


### PR DESCRIPTION
systemd-resolved resolves localhost and the hostname by default; libnss-myhostname additionally takes care of this. Creating the file leads to problems if hostnamectl is used to update the hostname later, since the file is not updated by that tool. Ref: https://github.com/pop-os/systemd/issues/5 

I wasn't sure if there might still be a reason to keep the function around. I removed it since this was the only place it was used, but engineering feedback is welcome on that.