### PR TITLE
Fix detection of missing encrypted partitions

### DIFF
--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -48,7 +48,7 @@ impl Disks {
                 if let Some(device_path) = part.identifiers.path.as_ref() {
                     part.identifiers.part_uuid = PartitionID::get_partuuid(&["/dev/disk/by-path/", device_path].concat()).map(|pid| pid.id);
                     if let Some(new_uuid) = part.identifiers.part_uuid.as_ref() {
-                        info!("found missing PartUUID for device ({device_path})");
+                        info!("found missing PartUUID ({new_uuid}) for device ({device_path})");
                     }
                 }
             }

--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -468,6 +468,9 @@ impl Disks {
                 thread::sleep(Duration::from_millis(1000));
             }
 
+            // Wait to allow the opened block devices to settle.
+            std::thread::sleep(Duration::from_secs(3));
+
             match pvs().expect("pvs() failed in decrypt_partition").remove(pv) {
                 Some(Some(vg)) => {
                     // Set values in the device's partition.

--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -45,12 +45,7 @@ impl Disks {
     pub fn rescan_partition_uuids(&mut self) {
         for part in self.get_partitions_mut() {
             if part.identifiers.part_uuid.is_none() {
-                if let Some(device_path) = part.identifiers.path.as_ref() {
-                    part.identifiers.part_uuid = PartitionID::get_partuuid(&["/dev/disk/by-path/", device_path].concat()).map(|pid| pid.id);
-                    if let Some(new_uuid) = part.identifiers.part_uuid.as_ref() {
-                        info!("found missing PartUUID ({new_uuid}) for device ({device_path})");
-                    }
-                }
+                part.identifiers.part_uuid = PartitionID::get_partuuid(part.get_device_path()).map(|pid| pid.id);
             }
         }
     }

--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -468,9 +468,6 @@ impl Disks {
                 thread::sleep(Duration::from_millis(1000));
             }
 
-            // Wait to allow the opened block devices to settle.
-            std::thread::sleep(Duration::from_secs(3));
-
             match pvs().expect("pvs() failed in decrypt_partition").remove(pv) {
                 Some(Some(vg)) => {
                     // Set values in the device's partition.

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -251,6 +251,8 @@ fn refresh_config(disks: &mut Disks, option: &RefreshOption) -> Result<(), Insta
             })
     });
 
+    info!("Cached disks: {:?}", disks);
+
     set_mount_by_identity(disks, &PartitionID::new_uuid(option.root_part.clone()), "/")?;
 
     if let Some(ref home) = option.home_part {

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -83,6 +83,8 @@ impl<'a> InstallOption<'a> {
     pub fn apply(self, disks: &mut Disks) -> Result<(), InstallOptionError> {
         disks.rescan_partition_uuids();
 
+        info!("applying configuration with {disks:#?}");
+
         match self {
             // Install alongside another OS, taking `sectors` from the largest free partition.
             InstallOption::Alongside { option, password, sectors } => {

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -81,6 +81,8 @@ impl<'a> InstallOption<'a> {
     ///
     /// Produces error if a partition or configuration file cannot be found.
     pub fn apply(self, disks: &mut Disks) -> Result<(), InstallOptionError> {
+        disks.rescan_partition_uuids();
+
         match self {
             // Install alongside another OS, taking `sectors` from the largest free partition.
             InstallOption::Alongside { option, password, sectors } => {
@@ -240,18 +242,6 @@ fn upgrade_config(disks: &mut Disks, option: &RecoveryOption) -> Result<(), Inst
 /// Apply a `refresh` config to `disks`.
 fn refresh_config(disks: &mut Disks, option: &RefreshOption) -> Result<(), InstallOptionError> {
     info!("applying refresh install config");
-
-    // List block devices in case we need to debug a refresh install
-    info!("lsblk dump: {:?}", {
-        std::process::Command::new("lsblk")
-            .args(&["-o", "NAME,PARTUUID,MOUNTPOINTS"])
-            .output()
-            .map(|output| {
-                String::from_utf8(output.stdout)
-            })
-    });
-
-    info!("Cached disks: {:?}", disks);
 
     set_mount_by_identity(disks, &PartitionID::new_uuid(option.root_part.clone()), "/")?;
 

--- a/src/auto/options/apply.rs
+++ b/src/auto/options/apply.rs
@@ -81,7 +81,7 @@ impl<'a> InstallOption<'a> {
     ///
     /// Produces error if a partition or configuration file cannot be found.
     pub fn apply(self, disks: &mut Disks) -> Result<(), InstallOptionError> {
-        disks.rescan_partition_uuids();
+        disks.rescan_partition_ids();
 
         info!("applying configuration with {disks:#?}");
 

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -73,11 +73,7 @@ impl InstallOptions {
                                 .expect("root device did not have uuid")
                                 .id,
                             home_part:      home.map(|pos| partitions[pos].clone()),
-                            efi_part:       {
-                                let efi_part = efi.map(|pos| partitions[pos].clone());
-                                info!("RefreshOption EFI Part: {:?}", efi_part);
-                                efi_part
-                            },
+                            efi_part:       efi.map(|pos| partitions[pos].clone()),
                             recovery_part:  recovery.map(|pos| partitions[pos].clone()),
                             can_retain_old: if let Ok(used) = part.sectors_used() {
                                 part.get_sectors() - used > required_space

--- a/src/auto/options/mod.rs
+++ b/src/auto/options/mod.rs
@@ -73,7 +73,11 @@ impl InstallOptions {
                                 .expect("root device did not have uuid")
                                 .id,
                             home_part:      home.map(|pos| partitions[pos].clone()),
-                            efi_part:       efi.map(|pos| partitions[pos].clone()),
+                            efi_part:       {
+                                let efi_part = efi.map(|pos| partitions[pos].clone());
+                                info!("RefreshOption EFI Part: {:?}", efi_part);
+                                efi_part
+                            },
                             recovery_part:  recovery.map(|pos| partitions[pos].clone()),
                             can_retain_old: if let Ok(used) = part.sectors_used() {
                                 part.get_sectors() - used > required_space
@@ -93,7 +97,7 @@ impl InstallOptions {
                 if device.is_read_only() || device.contains_mount("/", &disks) {
                     continue;
                 }
-                
+
                 eprintln!("device: {:?}", device.get_device_path());
 
                 let mut last_end_sector = 1024;


### PR DESCRIPTION
This is to debug an issue currently seen with our latest ISOs. This will add some extra logs to display the partition that failed to be applied for the refresh config, a dump of `lsblk` before applying the config, and a delay of 3 seconds before getting a list of volumes after a decrypted PV is online.