### PR TITLE
Allow probe_disks to ignore disks that cannot be read from

### DIFF
--- a/crates/disks/src/config/disks.rs
+++ b/crates/disks/src/config/disks.rs
@@ -600,7 +600,13 @@ impl Disks {
                     | DeviceType::PED_DEVICE_LOOP
                     | DeviceType::PED_DEVICE_FILE
                     | DeviceType::PED_DEVICE_DM => continue,
-                    _ => disks.add(Disk::new(&mut device, false)?),
+                    _ => { 
+                        let disk = Disk::new(&mut device, false);
+                        match disk {
+                            Ok(disk) => disks.add(disk),
+                            Err(error) => info!("unable to probe device: {}", err),
+                        }
+                    },
                 }
             }
         }


### PR DESCRIPTION
Do not hard error when probe_disks() tries to read one of the disks on a device cannot be read. Log the error instead and return the disks that can be read.

This allows certain model year MacBookPros to install Pop without deleting disks.