### PR TITLE
Do not install kernel for Ubuntu 24.04

### DIFF
--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -114,7 +114,8 @@ pub fn get_bootloader_packages(os_release: &OsRelease) -> io::Result<&'static [&
             "fwupd-signed",
             "grub-efi-amd64",
             "grub-efi-amd64-signed",
-            "linux-image-generic-hwe-24.04",
+            //TODO: HWE kernel not present on Ubuntu Server ISOs,
+            //but non-HWE kernel not present on Ubuntu Desktop ISOs...
             "mokutil",
             "shim-signed",
         ]),


### PR DESCRIPTION
This allows Ubuntu Server 24.04 images to be built.