### PR TITLE
Remove dmraid and kpartx-boot

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Depends:
   coreutils,
   cryptsetup,
   dmsetup,
-  dmraid,
   dosfstools,
   e2fsprogs,
   f2fs-tools,

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,6 @@ Depends:
   grub2-common,
   iso-codes,
   kpartx,
-  kpartx-boot,
   libparted-fs-resize0,
   locales,
   lvm2,

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -178,7 +178,7 @@ pub fn get_required_packages<D: InstallerDiskOps>(
     }
 
     if flags.intersects(FileSystemSupport::LVM | FileSystemSupport::LUKS) {
-        retain.extend_from_slice(&["lvm2", "dmeventd", "dmraid", "kpartx", "kpartx-boot"]);
+        retain.extend_from_slice(&["lvm2", "dmeventd", "kpartx", "kpartx-boot"]);
     }
 
     retain

--- a/src/distribution/debian.rs
+++ b/src/distribution/debian.rs
@@ -178,7 +178,7 @@ pub fn get_required_packages<D: InstallerDiskOps>(
     }
 
     if flags.intersects(FileSystemSupport::LVM | FileSystemSupport::LUKS) {
-        retain.extend_from_slice(&["lvm2", "dmeventd", "kpartx", "kpartx-boot"]);
+        retain.extend_from_slice(&["lvm2", "dmeventd", "kpartx"]);
     }
 
     retain


### PR DESCRIPTION
They were removed from Ubuntu https://bugs.launchpad.net/ubuntu/+source/dmraid/+bug/2073677 and are likely no longer needed for encrypted installs (please test!)

After merge, master_resolute can be removed

Related to https://github.com/pop-os/distinst-v2/pull/4