### PR TITLE
chore: control: Follow rename of libparted-fs-resize0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Depends:
   grub2-common,
   iso-codes,
   kpartx,
-  libparted-fs-resize0,
+  libparted-fs-resize0t64 | libparted-fs-resize0,
   locales,
   lvm2,
   mount,


### PR DESCRIPTION
`libparted-fs-resize0` is a transitional virtual package against `libparted-fs-resize0t64` since Noble as seen at:

https://packages.ubuntu.com/search?lang=en&suite=all&searchon=names&keywords=libparted-fs-resize0

And `libparted-fs-resize0` does not seem to exist for armhf, causing build error of Installer for elementary OS 8 (based on Noble) and Next (based on Resolute) for armhf on Launchpad ([recipe](https://code.launchpad.net/~elementary-os/+recipe/installer-daily), [full build log](https://launchpadlibrarian.net/857847605/buildlog_ubuntu-resolute-armhf.io.elementary.installer_8.1.3+r2189+pkg50~daily~ubuntu26.04.1_BUILDING.txt.gz)):

```
The following packages have unmet dependencies:
 sbuild-build-depends-main-dummy : Depends: debhelper (>= 9) but it is not going to be installed
                                   Depends: desktop-file-utils but it is not going to be installed
                                   Depends: gettext but it is not going to be installed
                                   Depends: libadwaita-1-dev but it is not going to be installed
                                   Depends: libdistinst-dev but it is not going to be installed
                                   Depends: libgee-0.8-dev but it is not going to be installed
                                   Depends: libgnomekbd-dev but it is not going to be installed
                                   Depends: libgranite-7-dev but it is not going to be installed
                                   Depends: libgtk-4-dev but it is not going to be installed
                                   Depends: libjson-glib-dev but it is not going to be installed
                                   Depends: libpantheon-wayland-1-dev but it is not going to be installed
                                   Depends: libpwquality-dev but it is not going to be installed
                                   Depends: libxkbregistry-dev but it is not going to be installed
                                   Depends: systemd-dev but it is not going to be installed
                                   Depends: meson but it is not going to be installed
                                   Depends: valac (>= 0.26) but it is not going to be installed
E: Unable to satisfy dependencies. Reached two conflicting assignments:
   1. libdistinst:armhf is selected for install because:
      1. sbuild-build-depends-main-dummy:armhf=0.invalid.0 is selected for install
      2. sbuild-build-depends-main-dummy:armhf Depends libdistinst-dev
      3. libdistinst-dev:armhf Depends libdistinst (= 0.3.2~1761087897~26.04~17ad93f~dev)
   2. libdistinst:armhf Depends libparted-fs-resize0
      but none of the choices are installable:
      [no choices]
apt-get failed.
E: Package installation failed
```

This PR should fix the above problem by adding `libparted-fs-resize0t64` as an alternative package name.
